### PR TITLE
Update fossa workflow's action version and trigger branches

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,16 +15,12 @@ name: fossa
 on:
   push:
     branches:
-      - master
-      - release-*
-      - feature/*
+      - main
     tags:
       - v*
   pull_request:
     branches:
-      - master
-      - release-*
-      - feature/*
+      - main
   workflow_dispatch: {}
 jobs:
   fossa-scan:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -37,12 +37,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: "Run FOSSA Scan"
-        uses: fossas/fossa-action@main # Use a specific version if locking is preferred
+        uses: fossas/fossa-action@v1.1.0 # Use a specific version if locking is preferred
         with:
           api-key: ${{ env.FOSSA_API_KEY }}
 
       - name: "Run FOSSA Test"
-        uses: fossas/fossa-action@main # Use a specific version if locking is preferred
+        uses: fossas/fossa-action@v1.1.0 # Use a specific version if locking is preferred
         with:
           api-key: ${{ env.FOSSA_API_KEY }}
           run-tests: true

--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run golangci-lint
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
-        uses: golangci/golangci-lint-action@v2.2.1
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           version: ${{ env.GOLANGCI_LINT_VER }}
       - name: Run make go.mod check-diff


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

1. Due to a recent regression in FOSSA action's main branch, we are moving to the last working version.
2. Update the trigger branches for the FOSSA workflow.

## Issue reference

Related to: https://github.com/dapr/dapr/issues/4523

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
