### PR TITLE
Enable custom output destination in Dapr Kit Logger

### DIFF
--- a/logger/dapr_logger.go
+++ b/logger/dapr_logger.go
@@ -107,7 +107,7 @@ func (l *daprLogger) WithLogType(logType string) Logger {
 	}
 }
 
-func (l *daprLogger) SetOuput(output io.Writer) {
+func (l *daprLogger) SetOutput(output io.Writer) {
 	l.logger.Logger.SetOutput(output)
 }
 

--- a/logger/dapr_logger.go
+++ b/logger/dapr_logger.go
@@ -14,6 +14,7 @@ limitations under the License.
 package logger
 
 import (
+	"io"
 	"os"
 	"time"
 
@@ -104,6 +105,10 @@ func (l *daprLogger) WithLogType(logType string) Logger {
 		name:   l.name,
 		logger: l.logger.WithField(logFieldType, logType),
 	}
+}
+
+func (l *daprLogger) SetOuput(output io.Writer) {
+	l.logger.Logger.SetOutput(output)
 }
 
 // Info logs a message at level Info.

--- a/logger/dapr_logger_test.go
+++ b/logger/dapr_logger_test.go
@@ -37,7 +37,7 @@ func getTestLogger(buf io.Writer) *daprLogger {
 func TestCustomOutputDestination(t *testing.T) {
 	var buf bytes.Buffer
 	l := newDaprLogger(fakeLoggerName)
-	l.SetOuput(&buf)
+	l.SetOutput(&buf)
 	l.EnableJSONOutput(true)
 	l.SetAppID("dapr_app")
 	l.SetOutputLevel(InfoLevel)

--- a/logger/dapr_logger_test.go
+++ b/logger/dapr_logger_test.go
@@ -34,6 +34,20 @@ func getTestLogger(buf io.Writer) *daprLogger {
 	return l
 }
 
+func TestCustomOutputDestination(t *testing.T) {
+	var buf bytes.Buffer
+	l := newDaprLogger(fakeLoggerName)
+	l.SetOuput(&buf)
+	l.EnableJSONOutput(true)
+	l.SetAppID("dapr_app")
+	l.SetOutputLevel(InfoLevel)
+	l.Info("testLogger with log LogType")
+	b, _ := buf.ReadBytes('\n')
+	var o map[string]interface{}
+	assert.NoError(t, json.Unmarshal(b, &o))
+	assert.Equal(t, LogTypeLog, o[logFieldType])
+}
+
 func TestEnableJSON(t *testing.T) {
 	var buf bytes.Buffer
 	testLogger := getTestLogger(&buf)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -68,7 +68,7 @@ type Logger interface {
 	EnableJSONOutput(enabled bool)
 
 	// Writes log messages to the specified io.Writer instead of stdout.
-	SetOuput(output io.Writer)
+	SetOutput(output io.Writer)
 
 	// SetAppID sets dapr_id field in the log. Default value is empty string
 	SetAppID(id string)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -14,6 +14,7 @@ limitations under the License.
 package logger
 
 import (
+	"io"
 	"strings"
 	"sync"
 )
@@ -65,6 +66,9 @@ var (
 type Logger interface {
 	// EnableJSONOutput enables JSON formatted output log
 	EnableJSONOutput(enabled bool)
+
+	// Writes log messages to the specified io.Writer instead of stdout.
+	SetOuput(output io.Writer)
 
 	// SetAppID sets dapr_id field in the log. Default value is empty string
 	SetAppID(id string)


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

This allows a custom output destination in Dapr Kit logger which is very handy for writing tests, allowing the use of for example a byte buffer instead of stdout.

Essentially this exposes the `logrus` method `SetOutput(output io.Writer)`

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
