### PR TITLE
Adds IsOutputLevelEnabled to allow wasm to opt-out of generating strings

### DIFF
--- a/logger/dapr_logger.go
+++ b/logger/dapr_logger.go
@@ -89,7 +89,7 @@ func (l *daprLogger) SetAppID(id string) {
 }
 
 func toLogrusLevel(lvl LogLevel) logrus.Level {
-	// ignore error because it will never happens
+	// ignore error because it will never happen
 	l, _ := logrus.ParseLevel(string(lvl))
 	return l
 }
@@ -97,6 +97,11 @@ func toLogrusLevel(lvl LogLevel) logrus.Level {
 // SetOutputLevel sets log output level.
 func (l *daprLogger) SetOutputLevel(outputLevel LogLevel) {
 	l.logger.Logger.SetLevel(toLogrusLevel(outputLevel))
+}
+
+// IsOutputLevelEnabled returns true if the logger will output this LogLevel.
+func (l *daprLogger) IsOutputLevelEnabled(level LogLevel) bool {
+	return l.logger.Logger.IsLevelEnabled(toLogrusLevel(level))
 }
 
 // SetOutput sets the destination for the logs.

--- a/logger/dapr_logger_test.go
+++ b/logger/dapr_logger_test.go
@@ -235,7 +235,6 @@ func TestOutputLevel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.outputLevel), func(t *testing.T) {
 			for l, want := range tt.expectedOutputLevels {
-
 				var buf bytes.Buffer
 				testLogger := getTestLogger(&buf)
 				testLogger.SetOutputLevel(tt.outputLevel)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -63,7 +63,7 @@ var (
 )
 
 // Logger includes the logging api sets.
-type Logger interface {
+type Logger interface { //nolint: interfacebloat
 	// EnableJSONOutput enables JSON formatted output log
 	EnableJSONOutput(enabled bool)
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -69,12 +69,16 @@ type Logger interface {
 
 	// SetAppID sets dapr_id field in the log. Default value is empty string
 	SetAppID(id string)
-	// SetOutputLevel sets log output level
+
+	// SetOutputLevel sets the log output level
 	SetOutputLevel(outputLevel LogLevel)
 	// SetOutput sets the destination for the logs
 	SetOutput(dst io.Writer)
 
-	// WithLogType specify the log_type field in log. Default value is LogTypeLog
+	// IsOutputLevelEnabled returns true if the logger will output this LogLevel.
+	IsOutputLevelEnabled(level LogLevel) bool
+
+	// WithLogType specifies the log_type field in log. Default value is LogTypeLog
 	WithLogType(logType string) Logger
 
 	// WithFields returns a logger with the added structured fields.


### PR DESCRIPTION
# Description

In WebAssembly, the host is dapr, and we can expose this to the guest (wasm binary compiled from rust, go, zig etc) to obviate calls. Allocation of log messages is expensive in WebAssembly. This exposes the underlying IsLevelEnabled as IsOutputLevelEnabled. This will allow request-scoped caching of this and help wasm filters avoid overhead created for no reason.

## Issue reference

https://github.com/dapr/dapr/issues/5003 will enhance wasm support soon.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
