### PR TITLE
Added debug methods to retry

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -15,6 +15,7 @@ package retry
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -53,8 +54,15 @@ type Config struct {
 	MaxRetries int64 `mapstructure:"maxRetries"`
 }
 
-// DefaultConfig represents the default configuration for a
-// `Config`.
+// String implements fmt.Stringer and is used for debugging.
+func (c Config) String() string {
+	return fmt.Sprintf(
+		"policy='%s' duration='%v' initialInterval='%v' randomizationFactor='%f' multiplier='%f' maxInterval='%v' maxElapsedTime='%v' maxRetries='%d'",
+		c.Policy, c.Duration, c.InitialInterval, c.RandomizationFactor, c.Multiplier, c.MaxInterval, c.MaxElapsedTime, c.MaxRetries,
+	)
+}
+
+// DefaultConfig represents the default configuration for a `Config`.
 func DefaultConfig() Config {
 	return Config{
 		Policy:              PolicyConstant,
@@ -175,6 +183,17 @@ func (p *PolicyType) DecodeString(value string) error {
 	default:
 		return errors.Errorf("unexpected back off policy type: %s", value)
 	}
-
 	return nil
+}
+
+// String implements fmt.Stringer and is used for debugging.
+func (p PolicyType) String() string {
+	switch p {
+	case PolicyConstant:
+		return "constant"
+	case PolicyExponential:
+		return "exponential"
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
Adds some `String()` methods to structs in the retry package to allow printing them out.

This is useful for debugging.