### PR TITLE
Add NotifyRecoverWithData that returns data too

### DIFF
--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: "1.18"
+      GOVER: "1.19"
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/kit
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3
@@ -18,3 +18,6 @@ require (
 	golang.org/x/sys v0.1.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// Temporary until https://github.com/cenkalti/backoff/pull/126 is merged
+replace github.com/cenkalti/backoff/v4 => github.com/ItalyPaleAle/backoff/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
-github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/ItalyPaleAle/backoff/v4 v4.2.0 h1:bcc9j45CtY0SURvcuoiGK2L5rq9ZTtfwUxUgwyZrLGw=
+github.com/ItalyPaleAle/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
# Description

In the `retry` package, add `NotifyRecoverWithData` which returns data in addition to an error.

This change requires a change upstream in the backoff library. For now, I have pinned my fork while we wait for the maintainer to approve the change (or not). See: https://github.com/cenkalti/backoff/pull/126

If the change doesn't get merged upstream, we'll fork the package entirely in this repo.

## Issue reference

Part of https://github.com/dapr/dapr/pull/5538

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
