### PR TITLE
Port time utils from dapr/dapr

### DIFF
--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -25,7 +25,7 @@ jobs:
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org
-      GOLANGCI_LINT_VER: v1.45.2
+      GOLANGCI_LINT_VER: v1.50.1
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/time/time.go
+++ b/time/time.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package time contains utilities for working with times, dates, and durations.
+package time
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+var pattern = regexp.MustCompile(`^(R(?P<repetition>\d+)/)?P((?P<year>\d+)Y)?((?P<month>\d+)M)?((?P<week>\d+)W)?((?P<day>\d+)D)?(T((?P<hour>\d+)H)?((?P<minute>\d+)M)?((?P<second>\d+)S)?)?$`)
+
+// ParseISO8601Duration parses a duration from a string in the ISO8601 duration format.
+func ParseISO8601Duration(from string) (int, int, int, time.Duration, int, error) {
+	match := pattern.FindStringSubmatch(from)
+	if match == nil {
+		return 0, 0, 0, 0, 0, fmt.Errorf("unsupported ISO8601 duration format %q", from)
+	}
+	years, months, days, duration := 0, 0, 0, time.Duration(0)
+	// -1 signifies infinite repetition
+	repetition := -1
+	for i, name := range pattern.SubexpNames() {
+		part := match[i]
+		if i == 0 || name == "" || part == "" {
+			continue
+		}
+		val, err := strconv.Atoi(part)
+		if err != nil {
+			return 0, 0, 0, 0, 0, err
+		}
+		switch name {
+		case "year":
+			years = val
+		case "month":
+			months = val
+		case "week":
+			days += 7 * val
+		case "day":
+			days += val
+		case "hour":
+			duration += time.Hour * time.Duration(val)
+		case "minute":
+			duration += time.Minute * time.Duration(val)
+		case "second":
+			duration += time.Second * time.Duration(val)
+		case "repetition":
+			repetition = val
+		default:
+			return 0, 0, 0, 0, 0, fmt.Errorf("unsupported ISO8601 duration field %s", name)
+		}
+	}
+	return years, months, days, duration, repetition, nil
+}
+
+// ParseDuration creates time.Duration from either:
+// - ISO8601 duration format
+// - time.Duration string format
+func ParseDuration(from string) (int, int, int, time.Duration, int, error) {
+	y, m, d, dur, r, err := ParseISO8601Duration(from)
+	if err == nil {
+		return y, m, d, dur, r, nil
+	}
+	dur, err = time.ParseDuration(from)
+	if err == nil {
+		return 0, 0, 0, dur, -1, nil
+	}
+	return 0, 0, 0, 0, 0, fmt.Errorf("unsupported duration format %q", from)
+}
+
+// ParseTime creates time.Duration from either:
+// - ISO8601 duration format
+// - time.Duration string format
+// - RFC3339 datetime format
+// For duration formats, an offset is added.
+func ParseTime(from string, offset *time.Time) (time.Time, error) {
+	var start time.Time
+	if offset != nil {
+		start = *offset
+	} else {
+		start = time.Now()
+	}
+	y, m, d, dur, r, err := ParseISO8601Duration(from)
+	if err == nil {
+		if r != -1 {
+			return time.Time{}, errors.New("repetitions are not allowed")
+		}
+		return start.AddDate(y, m, d).Add(dur), nil
+	}
+	if dur, err = time.ParseDuration(from); err == nil {
+		return start.Add(dur), nil
+	}
+	if t, err := time.Parse(time.RFC3339, from); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("unsupported time/duration format %q", from)
+}

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package time
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDuration(t *testing.T) {
+	t.Run("parse time.Duration", func(t *testing.T) {
+		y, m, d, duration, repetition, err := ParseDuration("0h30m0s")
+		assert.Nil(t, err)
+		assert.Equal(t, time.Minute*30, duration)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 0, m)
+		assert.Equal(t, 0, d)
+		assert.Equal(t, -1, repetition)
+	})
+	t.Run("parse ISO 8601 duration with repetition", func(t *testing.T) {
+		y, m, d, duration, repetition, err := ParseDuration("R5/P10Y5M3DT30M")
+		assert.Nil(t, err)
+		assert.Equal(t, 10, y)
+		assert.Equal(t, 5, m)
+		assert.Equal(t, 3, d)
+		assert.Equal(t, time.Minute*30, duration)
+		assert.Equal(t, 5, repetition)
+	})
+	t.Run("parse ISO 8601 duration without repetition", func(t *testing.T) {
+		y, m, d, duration, repetition, err := ParseDuration("P1MT2H10M3S")
+		assert.Nil(t, err)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 1, m)
+		assert.Equal(t, 0, d)
+		assert.Equal(t, time.Hour*2+time.Minute*10+time.Second*3, duration)
+		assert.Equal(t, -1, repetition)
+	})
+	t.Run("parse ISO 8610 and calculate with leap year", func(t *testing.T) {
+		y, m, d, dur, _, err := ParseDuration("P1Y2M3D")
+		assert.Nil(t, err)
+
+		// 2020 is a leap year
+		start, _ := time.Parse("2006-01-02 15:04:05", "2020-02-03 11:12:13")
+		target := start.AddDate(y, m, d).Add(dur)
+		expect, _ := time.Parse("2006-01-02 15:04:05", "2021-04-06 11:12:13")
+		assert.Equal(t, expect, target)
+
+		// 2019 is not a leap year
+		start, _ = time.Parse("2006-01-02 15:04:05", "2019-02-03 11:12:13")
+		target = start.AddDate(y, m, d).Add(dur)
+		expect, _ = time.Parse("2006-01-02 15:04:05", "2020-04-06 11:12:13")
+		assert.Equal(t, expect, target)
+	})
+	t.Run("parse RFC3339 datetime", func(t *testing.T) {
+		_, _, _, _, _, err := ParseDuration(time.Now().Add(time.Minute).Format(time.RFC3339))
+		assert.NotNil(t, err)
+	})
+	t.Run("parse empty string", func(t *testing.T) {
+		_, _, _, _, _, err := ParseDuration("")
+		assert.NotNil(t, err)
+	})
+}
+
+func TestParseTime(t *testing.T) {
+	t.Run("parse time.Duration without offset", func(t *testing.T) {
+		expected := time.Now().Add(30 * time.Minute)
+		tm, err := ParseTime("0h30m0s", nil)
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, tm.Sub(expected), time.Second*2)
+	})
+	t.Run("parse time.Duration with offset", func(t *testing.T) {
+		now := time.Now()
+		offs := 5 * time.Second
+		start := now.Add(offs)
+		expected := start.Add(30 * time.Minute)
+		tm, err := ParseTime("0h30m0s", &start)
+		assert.NoError(t, err)
+		assert.Equal(t, time.Duration(0), expected.Sub(tm))
+	})
+	t.Run("parse ISO 8601 duration with repetition", func(t *testing.T) {
+		_, err := ParseTime("R5/PT30M", nil)
+		assert.Error(t, err)
+	})
+	t.Run("parse ISO 8601 duration without repetition", func(t *testing.T) {
+		now, _ := time.Parse("2006-01-02 15:04:05", "2021-12-06 17:43:46")
+		offs := 5 * time.Second
+		start := now.Add(offs)
+		expected := start.Add(time.Hour*24*31 + time.Hour*2 + time.Minute*10 + time.Second*3)
+		tm, err := ParseTime("P1MT2H10M3S", &start)
+		assert.NoError(t, err)
+		assert.Equal(t, time.Duration(0), expected.Sub(tm))
+	})
+	t.Run("parse RFC3339 datetime", func(t *testing.T) {
+		dummy := time.Now().Add(5 * time.Minute)
+		expected := time.Now().Truncate(time.Minute).Add(time.Minute)
+		tm, err := ParseTime(expected.Format(time.RFC3339), &dummy)
+		assert.NoError(t, err)
+		assert.Equal(t, time.Duration(0), expected.Sub(tm))
+	})
+	t.Run("parse empty string", func(t *testing.T) {
+		_, err := ParseTime("", nil)
+		assert.EqualError(t, err, "unsupported time/duration format \"\"")
+	})
+}


### PR DESCRIPTION
This PR ports time utils from dapr/dapr (specifically [pkg/actors/actors.go](https://github.com/dapr/dapr/blob/01891417063587e34b77c149eef5b9aae592fac4/pkg/actors/actors.go#L2105)) into dapr/kit. No code changes, just feels like this is a better place for these utils rather than being buried at the end of a file in pkg/actors.

PS: Also updates the version of the linter to 1.50.1, the same one we are currently using on other Dapr repos