### PR TITLE
Misc updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,13 +118,16 @@ linters-settings:
     # minimal occurrences count to trigger, 3 by default
     min-occurrences: 5
   depguard:
-    list-type: blacklist
+    list-type: denylist
     include-go-root: false
-    packages:
-      - github.com/Sirupsen/logrus
-    packages-with-error-messages:
-      # specify an error message to output when a blacklisted package is used
-      github.com/Sirupsen/logrus: "must use github.com/sirupsen/logrus"
+    packages-with-error-message:
+      - "github.com/Sirupsen/logrus": "must use github.com/dapr/kit/logger"
+      - "github.com/agrea/ptr": "must use github.com/dapr/kit/ptr"
+      - "go.uber.org/atomic": "must use sync/atomic"
+      - "github.com/pkg/errors": "must use standard library (errors package and/or fmt.Errorf)"
+      - "github.com/cenkalti/backoff": "must use github.com/cenkalti/backoff/v4"
+      - "github.com/cenkalti/backoff/v2": "must use github.com/cenkalti/backoff/v4"
+      - "github.com/cenkalti/backoff/v3": "must use github.com/cenkalti/backoff/v4"
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.

--- a/config/decode.go
+++ b/config/decode.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -73,7 +72,7 @@ func decodeString(f reflect.Type, t reflect.Type, data any) (any, error) {
 
 	dataString, ok := data.(string)
 	if !ok {
-		return nil, errors.Errorf("expected string: got %s", reflect.TypeOf(data))
+		return nil, fmt.Errorf("expected string: got %T", data)
 	}
 
 	var result any
@@ -93,7 +92,7 @@ func decodeString(f reflect.Type, t reflect.Type, data any) (any, error) {
 				t = t.Elem()
 			}
 
-			return nil, errors.Errorf("invalid %s %q: %v", t.Name(), dataString, err)
+			return nil, fmt.Errorf("invalid %s %q: %v", t.Name(), dataString, err)
 		}
 
 		return result, nil
@@ -189,5 +188,5 @@ func invalidError(err error, msg, value string) error {
 		return nil
 	}
 
-	return errors.Errorf("invalid %s %q", msg, value)
+	return fmt.Errorf("invalid %s %q", msg, value)
 }

--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -14,7 +14,7 @@ You can check the original license at:
 		https://github.com/robfig/cron/blob/master/LICENSE
 */
 
-//nolint
+//nolint:dupword
 package cron
 
 import (
@@ -33,6 +33,8 @@ import (
 // Many tests schedule a job for every second, and then wait at most a second
 // for it to run.  This amount is just slightly larger than 1 second to
 // compensate for a few milliseconds of runtime.
+//
+//nolint:revive
 const OneSecond = 1*time.Second + 50*time.Millisecond
 
 type syncWriter struct {
@@ -40,6 +42,7 @@ type syncWriter struct {
 	m  sync.Mutex
 }
 
+//nolint:nonamedreturns
 func (sw *syncWriter) Write(data []byte) (n int, err error) {
 	sw.m.Lock()
 	n, err = sw.wr.Write(data)
@@ -484,9 +487,10 @@ func TestJob(t *testing.T) {
 	// Ensure the entries are in the right order.
 	expecteds := []string{"job2", "job4", "job5", "job1", "job3", "job0"}
 
-	var actuals []string
-	for _, entry := range cron.Entries() {
-		actuals = append(actuals, entry.Job.(testJob).name)
+	cronEntries := cron.Entries()
+	actuals := make([]string, len(cronEntries))
+	for i, entry := range cronEntries {
+		actuals[i] = entry.Job.(testJob).name
 	}
 
 	for i, expected := range expecteds {
@@ -693,9 +697,9 @@ func TestMockClock(t *testing.T) {
 	clk := clock.NewMock()
 	clk.Set(time.Now())
 	cron := New(WithClock(clk))
-	counter := 0
+	counter := atomic.Uint64{}
 	cron.AddFunc("@every 1s", func() {
-		counter += 1
+		counter.Add(1)
 	})
 	cron.Start()
 	defer cron.Stop()
@@ -703,8 +707,8 @@ func TestMockClock(t *testing.T) {
 		clk.Add(1 * time.Second)
 	}
 	time.Sleep(100 * time.Millisecond)
-	if counter != 10 {
-		t.Errorf("expected 10 calls, got %d", counter)
+	if counter.Load() != 10 {
+		t.Errorf("expected 10 calls, got %d", counter.Load())
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,15 +7,14 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
-	golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f
+	golang.org/x/exp v0.0.0-20230105000112-eab7a2c85304
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/sys v0.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4 h1:BpfhmLKZf+SjVanKKhCgf3bg+511DmU9eDQTen7LLbY=
 github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
@@ -25,10 +23,14 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f h1:Al51T6tzvuh3oiwX11vex3QgJ2XTedFPGmbEVh8cdoc=
 golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230105000112-eab7a2c85304 h1:YUqj+XKtfrn3kXjFIiZ8jwKROD7ioAOOHUuo3ZZ2opc=
+golang.org/x/exp v0.0.0-20230105000112-eab7a2c85304/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/logger/nop_logger.go
+++ b/logger/nop_logger.go
@@ -15,7 +15,9 @@ limitations under the License.
 
 package logger
 
-import "io"
+import (
+	"io"
+)
 
 type nopLogger struct{}
 

--- a/logger/options.go
+++ b/logger/options.go
@@ -14,7 +14,7 @@ limitations under the License.
 package logger
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 const (
@@ -38,7 +38,7 @@ type Options struct {
 // SetOutputLevel sets the log output level.
 func (o *Options) SetOutputLevel(outputLevel string) error {
 	if toLogLevel(outputLevel) == UndefinedLevel {
-		return errors.Errorf("undefined Log Output Level: %s", outputLevel)
+		return fmt.Errorf("undefined Log Output Level: %s", outputLevel)
 	}
 	o.OutputLevel = outputLevel
 	return nil
@@ -94,7 +94,7 @@ func ApplyOptionsToLoggers(options *Options) error {
 
 	daprLogLevel := toLogLevel(options.OutputLevel)
 	if daprLogLevel == UndefinedLevel {
-		return errors.Errorf("invalid value for --log-level: %s", options.OutputLevel)
+		return fmt.Errorf("invalid value for --log-level: %s", options.OutputLevel)
 	}
 
 	for _, v := range internalLoggers {

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/pkg/errors"
 
 	"github.com/dapr/kit/config"
 )
@@ -199,7 +198,7 @@ func (p *PolicyType) DecodeString(value string) error {
 	case "exponential":
 		*p = PolicyExponential
 	default:
-		return errors.Errorf("unexpected back off policy type: %s", value)
+		return fmt.Errorf("unexpected back off policy type: %s", value)
 	}
 	return nil
 }


### PR DESCRIPTION
1. Removed `github.com/pkg/errors` and replaced with the standard library (linter now rejects the old package)
2. Cron test: fixed race conditions and linting
3. Renamed `logger/default.go` to `logger/nop_logger.go` to match the name of the struct inside