### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners are the maintainers and approvers of this repo
-*       @dapr/maintainers-kit @dapr/approvers-kit
+*       @dapr/maintainers-components-contrib @dapr/maintainers-dapr @dapr/approvers-components-contrib @dapr/approvers-dapr


### PR DESCRIPTION
Update CODEOWNERS in line with https://github.com/dapr/community/issues/248

Signed-off-by: Bernd Verst <github@bernd.dev>

# Description

No dedicated `maintainers-kit` group will be used, instead we use `maintainers-components-contrib`, `maintainers-dapr`, `approvers-components-contrib`, `approvers-dapr`
