### PR TITLE
Refactored ParseISO8601Duration for 18x perf improvement

### DIFF
--- a/time/time.go
+++ b/time/time.go
@@ -14,6 +14,8 @@ limitations under the License.
 */
 
 // Package time contains utilities for working with times, dates, and durations.
+//
+//nolint:nakedret,nonamedreturns
 package time
 
 import (

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -23,18 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func BenchmarkParseISO8601Duration_New(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		ParseISO8601Duration_New("R5/P10Y5M3DT30M")
-	}
-}
-
-func BenchmarkParseISO8601Duration(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		ParseISO8601Duration("R5/P10Y5M3DT30M")
-	}
-}
-
 func TestParseDuration(t *testing.T) {
 	t.Run("parse time.Duration", func(t *testing.T) {
 		y, m, d, duration, repetition, err := ParseDuration("0h30m0s")
@@ -227,6 +215,6 @@ func TestParseTime(t *testing.T) {
 	})
 	t.Run("parse empty string", func(t *testing.T) {
 		_, err := ParseTime("", nil)
-		assert.EqualError(t, err, "unsupported time/duration format \"\"")
+		assert.ErrorContains(t, err, "unsupported time/duration format")
 	})
 }

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -109,7 +109,6 @@ func TestParseDuration(t *testing.T) {
 		assert.Equal(t, 2, d)
 		assert.Equal(t, time.Duration(0), duration)
 		assert.Equal(t, -1, repetition)
-
 	})
 
 	t.Run("parse ISO 8601 duration with repetition only", func(t *testing.T) {

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -20,39 +20,132 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func BenchmarkParseISO8601Duration_New(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ParseISO8601Duration_New("R5/P10Y5M3DT30M")
+	}
+}
+
+func BenchmarkParseISO8601Duration(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ParseISO8601Duration("R5/P10Y5M3DT30M")
+	}
+}
 
 func TestParseDuration(t *testing.T) {
 	t.Run("parse time.Duration", func(t *testing.T) {
 		y, m, d, duration, repetition, err := ParseDuration("0h30m0s")
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, time.Minute*30, duration)
 		assert.Equal(t, 0, y)
 		assert.Equal(t, 0, m)
 		assert.Equal(t, 0, d)
 		assert.Equal(t, -1, repetition)
 	})
+
 	t.Run("parse ISO 8601 duration with repetition", func(t *testing.T) {
 		y, m, d, duration, repetition, err := ParseDuration("R5/P10Y5M3DT30M")
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 10, y)
 		assert.Equal(t, 5, m)
 		assert.Equal(t, 3, d)
 		assert.Equal(t, time.Minute*30, duration)
 		assert.Equal(t, 5, repetition)
 	})
+
 	t.Run("parse ISO 8601 duration without repetition", func(t *testing.T) {
 		y, m, d, duration, repetition, err := ParseDuration("P1MT2H10M3S")
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 0, y)
 		assert.Equal(t, 1, m)
 		assert.Equal(t, 0, d)
 		assert.Equal(t, time.Hour*2+time.Minute*10+time.Second*3, duration)
 		assert.Equal(t, -1, repetition)
+
+		y, m, d, duration, repetition, err = ParseDuration("P2W")
+		require.NoError(t, err)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 0, m)
+		assert.Equal(t, 14, d)
+		assert.Equal(t, time.Duration(0), duration)
+		assert.Equal(t, -1, repetition)
+
+		y, m, d, duration, repetition, err = ParseDuration("PT1S")
+		require.NoError(t, err)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 0, m)
+		assert.Equal(t, 0, d)
+		assert.Equal(t, time.Second, duration)
+		assert.Equal(t, -1, repetition)
+
+		y, m, d, duration, repetition, err = ParseDuration("P1M")
+		require.NoError(t, err)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 1, m)
+		assert.Equal(t, 0, d)
+		assert.Equal(t, time.Duration(0), duration)
+		assert.Equal(t, -1, repetition)
+
+		y, m, d, duration, repetition, err = ParseDuration("PT1M")
+		require.NoError(t, err)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 0, m)
+		assert.Equal(t, 0, d)
+		assert.Equal(t, time.Minute, duration)
+		assert.Equal(t, -1, repetition)
+
+		y, m, d, duration, repetition, err = ParseDuration("P0D")
+		require.NoError(t, err)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 0, m)
+		assert.Equal(t, 0, d)
+		assert.Equal(t, time.Duration(0), duration)
+		assert.Equal(t, -1, repetition)
+
+		y, m, d, duration, repetition, err = ParseDuration("PT0S")
+		require.NoError(t, err)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 0, m)
+		assert.Equal(t, 0, d)
+		assert.Equal(t, time.Duration(0), duration)
+		assert.Equal(t, -1, repetition)
+
+		// This is technically invalid because it's out of order, but we'll accept anyways
+		y, m, d, duration, repetition, err = ParseDuration("P1M2D")
+		require.NoError(t, err)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 1, m)
+		assert.Equal(t, 2, d)
+		assert.Equal(t, time.Duration(0), duration)
+		assert.Equal(t, -1, repetition)
+
 	})
-	t.Run("parse ISO 8610 and calculate with leap year", func(t *testing.T) {
+
+	t.Run("parse ISO 8601 duration with repetition only", func(t *testing.T) {
+		y, m, d, duration, repetition, err := ParseDuration("R5")
+		require.NoError(t, err)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 0, m)
+		assert.Equal(t, 0, d)
+		assert.Equal(t, time.Duration(0), duration)
+		assert.Equal(t, 5, repetition)
+
+		// With ending slash
+		y, m, d, duration, repetition, err = ParseDuration("R5/")
+		require.NoError(t, err)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 0, m)
+		assert.Equal(t, 0, d)
+		assert.Equal(t, time.Duration(0), duration)
+		assert.Equal(t, 5, repetition)
+	})
+
+	t.Run("parse ISO8610 and calculate with leap year", func(t *testing.T) {
 		y, m, d, dur, _, err := ParseDuration("P1Y2M3D")
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		// 2020 is a leap year
 		start, _ := time.Parse("2006-01-02 15:04:05", "2020-02-03 11:12:13")
@@ -66,13 +159,33 @@ func TestParseDuration(t *testing.T) {
 		expect, _ = time.Parse("2006-01-02 15:04:05", "2020-04-06 11:12:13")
 		assert.Equal(t, expect, target)
 	})
+
 	t.Run("parse RFC3339 datetime", func(t *testing.T) {
 		_, _, _, _, _, err := ParseDuration(time.Now().Add(time.Minute).Format(time.RFC3339))
-		assert.NotNil(t, err)
+		require.Error(t, err)
 	})
+
 	t.Run("parse empty string", func(t *testing.T) {
 		_, _, _, _, _, err := ParseDuration("")
-		assert.NotNil(t, err)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid ISO8601 duration", func(t *testing.T) {
+		// Doesn't start with P
+		_, _, _, _, _, err := ParseDuration("10D1M")
+		require.Error(t, err)
+
+		// Invalid formats
+		_, _, _, _, _, err = ParseDuration("P")
+		require.Error(t, err)
+		_, _, _, _, _, err = ParseDuration("PM")
+		require.Error(t, err)
+		_, _, _, _, _, err = ParseDuration("PT1D")
+		require.Error(t, err)
+		_, _, _, _, _, err = ParseDuration("P_D")
+		require.Error(t, err)
+		_, _, _, _, _, err = ParseDuration("PTxS")
+		require.Error(t, err)
 	})
 }
 
@@ -80,7 +193,7 @@ func TestParseTime(t *testing.T) {
 	t.Run("parse time.Duration without offset", func(t *testing.T) {
 		expected := time.Now().Add(30 * time.Minute)
 		tm, err := ParseTime("0h30m0s", nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.LessOrEqual(t, tm.Sub(expected), time.Second*2)
 	})
 	t.Run("parse time.Duration with offset", func(t *testing.T) {
@@ -89,7 +202,7 @@ func TestParseTime(t *testing.T) {
 		start := now.Add(offs)
 		expected := start.Add(30 * time.Minute)
 		tm, err := ParseTime("0h30m0s", &start)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, time.Duration(0), expected.Sub(tm))
 	})
 	t.Run("parse ISO 8601 duration with repetition", func(t *testing.T) {
@@ -102,14 +215,14 @@ func TestParseTime(t *testing.T) {
 		start := now.Add(offs)
 		expected := start.Add(time.Hour*24*31 + time.Hour*2 + time.Minute*10 + time.Second*3)
 		tm, err := ParseTime("P1MT2H10M3S", &start)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, time.Duration(0), expected.Sub(tm))
 	})
 	t.Run("parse RFC3339 datetime", func(t *testing.T) {
 		dummy := time.Now().Add(5 * time.Minute)
 		expected := time.Now().Truncate(time.Minute).Add(time.Minute)
 		tm, err := ParseTime(expected.Format(time.RFC3339), &dummy)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, time.Duration(0), expected.Sub(tm))
 	})
 	t.Run("parse empty string", func(t *testing.T) {


### PR DESCRIPTION
# Description

This PR rewrites ParseISO8601Duration, which is used in hot paths in actors, to use a "custom parser" rather than one based on regular expressions.

Benchmarks show a ~18x speed improvement, and heap allocations were reduced from 2 to 0.

```text
Parsing string: "R5/P10Y5M3DT30M"

goos: linux
goarch: amd64
pkg: github.com/dapr/kit/time
cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
BenchmarkParseISO8601Duration_New
BenchmarkParseISO8601Duration_New-4   	19521801	        61.46 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseISO8601Duration
BenchmarkParseISO8601Duration-4       	 1000000	      1113 ns/op	     578 B/op	       2 allocs/op
```

Many tests have been added to ensure the parser behaves correctly and supports all previous formats.