### PR TITLE
Use ASN.1 serialization for ECDSA signatures

### DIFF
--- a/crypto/asymmetric_sig.go
+++ b/crypto/asymmetric_sig.go
@@ -21,7 +21,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
-	"math/big"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -70,11 +69,7 @@ func signPrivateKeyECDSA(digest []byte, key jwk.Key) ([]byte, error) {
 		return nil, ErrKeyTypeMismatch
 	}
 
-	r, s, err := ecdsa.Sign(rand.Reader, ecdsaKey, digest)
-	if err != nil {
-		return nil, err
-	}
-	return append(r.Bytes(), s.Bytes()...), nil
+	return ecdsa.SignASN1(rand.Reader, ecdsaKey, digest)
 }
 
 func signPrivateKeyEdDSA(message []byte, key jwk.Key) ([]byte, error) {
@@ -162,13 +157,7 @@ func verifyPublicKeyECDSA(digest []byte, signature []byte, key jwk.Key) (bool, e
 		return false, ErrKeyTypeMismatch
 	}
 
-	n := len(signature) / 2
-	r := &big.Int{}
-	r.SetBytes(signature[:n])
-	s := &big.Int{}
-	s.SetBytes(signature[n:])
-
-	return ecdsa.Verify(ecdsaKey, digest, r, s), nil
+	return ecdsa.VerifyASN1(ecdsaKey, digest, signature), nil
 }
 
 func verifyPublicKeyEdDSA(mesage []byte, signature []byte, key jwk.Key) (bool, error) {


### PR DESCRIPTION
Methods to create and verify ECDSA signatures were previously serializing the output in "raw" format (i.e. `r || s`). However, they were not padding the bytes correctly, so sometimes signature verification would fail.

This changes the methods to encode the result using ASN.1 encoding, which is probably what we should have done from the beginning.