### PR TITLE
Add jwkscache package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,14 @@ go 1.20
 
 require (
 	github.com/benbjohnson/clock v1.3.0
-	github.com/cenkalti/backoff/v4 v4.2.0
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/fsnotify/fsnotify v1.6.0
+	github.com/lestrrat-go/httprc v1.0.4
 	github.com/lestrrat-go/jwx/v2 v2.0.9
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.2
-	golang.org/x/crypto v0.7.0
+	golang.org/x/crypto v0.8.0
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 )
 
@@ -20,10 +21,9 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.1 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
-	github.com/lestrrat-go/httprc v1.0.4 // indirect
 	github.com/lestrrat-go/iter v1.0.2 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
-github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -43,8 +43,9 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
+golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
+golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
 golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
 golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
@@ -65,8 +66,9 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/jwkscache/cache.go
+++ b/jwkscache/cache.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package jwkscache contains utils to manage a cache of a JWK Set (via jwk.Set).
+// It supports retrieving a JWKS from:
+//
+// - A path on the local disk. This is watched with fsnotify to automatically reload the JWKS when the file changes on disk.
+// - A HTTP(S) URL. This is automatically refreshed if a caller requests a key that isn't in the cached set.
+// - A JWKS passed during initialization, optionally base64-encoded.
+package jwkscache
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/lestrrat-go/httprc"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+
+	"github.com/dapr/kit/fswatcher"
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	// Timeout for network requests.
+	defaultRequestTimeout = 30 * time.Second
+	// Minimum interval for refreshing a JWKS from a URL if a key is not found in the cache.
+	defaultMinRefreshInterval = 10 * time.Minute
+)
+
+// JWKSCache is a cache of JWKS objects.
+// It fetches a JWKS object from a file on disk, a URL, or from a value passed as-is.
+// TODO: Move this to dapr/kit and use it for the JWKS crypto component too
+type JWKSCache struct {
+	location           string
+	requestTimeout     time.Duration
+	minRefreshInterval time.Duration
+
+	jwks    jwk.Set
+	logger  logger.Logger
+	lock    sync.RWMutex
+	client  *http.Client
+	running atomic.Bool
+}
+
+// NewJWKSCache creates a new JWKSCache object.
+func NewJWKSCache(location string, logger logger.Logger) *JWKSCache {
+	return &JWKSCache{
+		location: location,
+		logger:   logger,
+
+		requestTimeout:     defaultRequestTimeout,
+		minRefreshInterval: defaultMinRefreshInterval,
+	}
+}
+
+// Start the JWKS cache.
+// This method blocks until the context is canceled.
+func (c *JWKSCache) Start(ctx context.Context) error {
+	if !c.running.CompareAndSwap(false, true) {
+		return errors.New("cache is already running")
+	}
+	defer c.running.Store(false)
+
+	// Init the cache
+	err := c.initCache(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to init cache: %w", err)
+	}
+
+	// Block until context is canceled
+	<-ctx.Done()
+
+	return nil
+}
+
+// SetRequestTimeout sets the timeout for network requests.
+func (c *JWKSCache) SetRequestTimeout(requestTimeout time.Duration) {
+	c.requestTimeout = requestTimeout
+}
+
+// SetMinRefreshInterval sets the minimum interval for refreshing a JWKS from a URL if a key is not found in the cache.
+func (c *JWKSCache) SetMinRefreshInterval(minRefreshInterval time.Duration) {
+	c.minRefreshInterval = minRefreshInterval
+}
+
+// SetHTTPClient sets the HTTP client object to use.
+func (c *JWKSCache) SetHTTPClient(client *http.Client) {
+	c.client = client
+}
+
+// KeySet returns the jwk.Set with the current keys.
+func (c *JWKSCache) KeySet() jwk.Set {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.jwks
+}
+
+// Init the cache from the given location.
+func (c *JWKSCache) initCache(ctx context.Context) error {
+	if len(c.location) == 0 {
+		return errors.New("property 'location' must not be empty")
+	}
+
+	// If the location starts with "https://" or "http://", treat it as URL
+	if strings.HasPrefix(c.location, "https://") {
+		return c.initJWKSFromURL(ctx, c.location)
+	} else if strings.HasPrefix(c.location, "http://") {
+		c.logger.Warn("Loading JWK from an HTTP endpoint without TLS: this is not recommended on production environments.")
+		return c.initJWKSFromURL(ctx, c.location)
+	}
+
+	// Check if the location is a valid path to a local file
+	stat, err := os.Stat(c.location)
+	if err == nil && stat != nil && !stat.IsDir() {
+		return c.initJWKSFromFile(ctx, c.location)
+	}
+
+	// Treat the location as the actual JWKS
+	// First, check if it's base64-encoded (remove trailing padding chars if present first)
+	locationJSON, err := base64.RawStdEncoding.DecodeString(strings.TrimRight(c.location, "="))
+	if err != nil {
+		// Assume it's already JSON, not encoded
+		locationJSON = []byte(c.location)
+	}
+
+	// Try decoding from JSON
+	c.jwks, err = jwk.Parse(locationJSON)
+	if err != nil {
+		return errors.New("failed to parse property 'location': not a URL, path to local file, or JSON value (optionally base64-encoded)")
+	}
+
+	return nil
+}
+
+func (c *JWKSCache) initJWKSFromURL(ctx context.Context, url string) error {
+	// Create the JWKS cache
+	cache := jwk.NewCache(ctx,
+		jwk.WithErrSink(httprc.ErrSinkFunc(func(err error) {
+			c.logger.Warnf("Error while refreshing JWKS cache: %v", err)
+		})),
+	)
+
+	// We also need to create a custom HTTP client (if we don't have one already) because otherwise there's no timeout.
+	if c.client == nil {
+		c.client = &http.Client{
+			Timeout: c.requestTimeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					MinVersion: tls.VersionTLS12,
+				},
+			},
+		}
+	}
+
+	// Register the cache
+	err := cache.Register(url,
+		jwk.WithMinRefreshInterval(c.minRefreshInterval),
+		jwk.WithHTTPClient(c.client),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to register JWKS cache: %w", err)
+	}
+
+	// Fetch the JWKS right away to start, so we can check it's valid and populate the cache
+	refreshCtx, refreshCancel := context.WithTimeout(ctx, c.requestTimeout)
+	_, err = cache.Refresh(refreshCtx, url)
+	refreshCancel()
+	if err != nil {
+		return fmt.Errorf("failed to fetch JWKS: %w", err)
+	}
+
+	c.jwks = jwk.NewCachedSet(cache, url)
+	return nil
+}
+
+func (c *JWKSCache) initJWKSFromFile(ctx context.Context, file string) error {
+	// Get the path to the folder containing the file
+	path := filepath.Dir(file)
+
+	// Start watching for changes in the filesystem
+	eventCh := make(chan struct{})
+	loaded := make(chan error, 1) // Needs to be buffered to prevent a goroutine leak
+	go func() {
+		watchErr := fswatcher.Watch(ctx, path, eventCh)
+		if watchErr != nil && !errors.Is(watchErr, context.Canceled) {
+			// Log errors only
+			c.logger.Errorf("Error while watching for changes to the local JWKS file: %v", watchErr)
+		}
+	}()
+	go func() {
+		var firstDone bool
+		for {
+			select {
+			case <-eventCh:
+				// When there's a change, reload the JWKS file
+				err := c.parseJWKSFile(file)
+				if !firstDone {
+					// The first time, signal that the initialization was complete and pass the error
+					loaded <- err
+					close(loaded)
+					firstDone = true
+				} else if err != nil {
+					// Log errors only
+					c.logger.Errorf("Error reading JWKS from disk: %v", err)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Trigger a refresh immediately and wait for the first reload
+	eventCh <- struct{}{}
+
+	select {
+	case err := <-loaded:
+		// Error could be nil if everything is fine
+		return err
+	case <-time.After(5 * time.Second):
+		// If we don't get a response in 5s, something bad's going on
+		return errors.New("failed to initialize JWKS from file: no file loaded after 5s")
+	case <-ctx.Done():
+		return fmt.Errorf("failed to initialize JWKS from file: %w", ctx.Err())
+	}
+}
+
+// Used by initJWKSFromFile to parse a JWKS file every time it's changed
+func (c *JWKSCache) parseJWKSFile(file string) error {
+	c.logger.Debugf("Reloading JWKS file from disk")
+
+	read, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("failed to read JWKS file: %v", err)
+	}
+
+	jwks, err := jwk.Parse(read)
+	if err != nil {
+		return fmt.Errorf("failed to parse JWKS file: %v", err)
+	}
+
+	c.lock.Lock()
+	c.jwks = jwks
+	c.lock.Unlock()
+
+	return nil
+}

--- a/jwkscache/cache.go
+++ b/jwkscache/cache.go
@@ -214,6 +214,11 @@ func (c *JWKSCache) initJWKSFromFile(ctx context.Context, file string) error {
 			select {
 			case <-eventCh:
 				// When there's a change, reload the JWKS file
+				if firstDone {
+					c.logger.Debugf("Reloading JWKS file from disk")
+				} else {
+					c.logger.Debugf("Loading JWKS file from disk")
+				}
 				err := c.parseJWKSFile(file)
 				if !firstDone {
 					// The first time, signal that the initialization was complete and pass the error
@@ -247,8 +252,6 @@ func (c *JWKSCache) initJWKSFromFile(ctx context.Context, file string) error {
 
 // Used by initJWKSFromFile to parse a JWKS file every time it's changed
 func (c *JWKSCache) parseJWKSFile(file string) error {
-	c.logger.Debugf("Reloading JWKS file from disk")
-
 	read, err := os.ReadFile(file)
 	if err != nil {
 		return fmt.Errorf("failed to read JWKS file: %v", err)

--- a/jwkscache/cache.go
+++ b/jwkscache/cache.go
@@ -215,9 +215,9 @@ func (c *JWKSCache) initJWKSFromFile(ctx context.Context, file string) error {
 			case <-eventCh:
 				// When there's a change, reload the JWKS file
 				if firstDone {
-					c.logger.Debugf("Reloading JWKS file from disk")
+					c.logger.Debug("Reloading JWKS file from disk")
 				} else {
-					c.logger.Debugf("Loading JWKS file from disk")
+					c.logger.Debug("Loading JWKS file from disk")
 				}
 				err := c.parseJWKSFile(file)
 				if !firstDone {

--- a/jwkscache/cache_test.go
+++ b/jwkscache/cache_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jwkscache
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/kit/logger"
+)
+
+const (
+	testJWKS1 = `{"keys":[{"kid":"mykey","alg":"RS256","kty":"RSA","use":"sig","e":"AQAB","n":"3I2mdIK4mRRu-ywMrYjUZzBxt0NlAVLrMhGlaJsby7PWTMiLpZVip4SBD9GwnCU0TGFD7k2-7tfs0y9U6WV7MwgCjc9m_DUUGbE-kKjEU7JYkLzYlndys-6xuhD4Jf1hu9AZVdfXftpWSy_NNg6fVwTH4nckOAbOSL1hXToOYWQcDDW95Rhw3U4z04PqssEpRKn5KGBuTahNNNiZcWns99pChpLTxgdm93LjMBI1KCGBpOaz7fcQJ9V3c6rSwMKyY3IPm1LwS6PIs7xb2ZJ0Eb8A6MtCkGhgNsodpkxhqKbqtxI-KqTuZy9g4jb8WKjJq9lB9q-HPHoQqIEDom6P8w"}]}`
+	testJWKS2 = `{"keys":[{"kid":"mykey","alg":"RS256","kty":"RSA","use":"sig","e":"AQAB","n":"3I2mdIK4mRRu-ywMrYjUZzBxt0NlAVLrMhGlaJsby7PWTMiLpZVip4SBD9GwnCU0TGFD7k2-7tfs0y9U6WV7MwgCjc9m_DUUGbE-kKjEU7JYkLzYlndys-6xuhD4Jf1hu9AZVdfXftpWSy_NNg6fVwTH4nckOAbOSL1hXToOYWQcDDW95Rhw3U4z04PqssEpRKn5KGBuTahNNNiZcWns99pChpLTxgdm93LjMBI1KCGBpOaz7fcQJ9V3c6rSwMKyY3IPm1LwS6PIs7xb2ZJ0Eb8A6MtCkGhgNsodpkxhqKbqtxI-KqTuZy9g4jb8WKjJq9lB9q-HPHoQqIEDom6P8w"},{"alg":"RS256","kty":"RSA","use":"sig","n":"yeNlzlub94YgerT030codqEztjfU_S6X4DbDA_iVKkjAWtYfPHDzz_sPCT1Axz6isZdf3lHpq_gYX4Sz-cbe4rjmigxUxr-FgKHQy3HeCdK6hNq9ASQvMK9LBOpXDNn7mei6RZWom4wo3CMvvsY1w8tjtfLb-yQwJPltHxShZq5-ihC9irpLI9xEBTgG12q5lGIFPhTl_7inA1PFK97LuSLnTJzW0bj096v_TMDg7pOWm_zHtF53qbVsI0e3v5nmdKXdFf9BjIARRfVrbxVxiZHjU6zL6jY5QJdh1QCmENoejj_ytspMmGW7yMRxzUqgxcAqOBpVm0b-_mW3HoBdjQ","e":"AQAB","kid":"testkey"}]}`
+)
+
+func TestJWKSCache(t *testing.T) {
+	log := logger.NewLogger("test")
+
+	t.Run("init with value", func(t *testing.T) {
+		cache := NewJWKSCache(testJWKS1, log)
+		err := cache.initCache(context.Background())
+		require.NoError(t, err)
+
+		set := cache.KeySet()
+		require.Equal(t, 1, set.Len())
+
+		key, ok := set.LookupKeyID("mykey")
+		require.True(t, ok)
+		require.NotNil(t, key)
+	})
+
+	t.Run("init with base64-encoded value", func(t *testing.T) {
+		cache := NewJWKSCache(base64.StdEncoding.EncodeToString([]byte(testJWKS1)), log)
+		err := cache.initCache(context.Background())
+		require.NoError(t, err)
+
+		set := cache.KeySet()
+		require.Equal(t, 1, set.Len())
+
+		key, ok := set.LookupKeyID("mykey")
+		require.True(t, ok)
+		require.NotNil(t, key)
+	})
+
+	t.Run("init with local file", func(t *testing.T) {
+		// Create a temporary directory and put the JWKS in there
+		dir := t.TempDir()
+		path := filepath.Join(dir, "jwks.json")
+		err := os.WriteFile(path, []byte(testJWKS1), 0o666)
+		require.NoError(t, err)
+
+		// Should wait for first file to be loaded before initialization is reported as completed
+		cache := NewJWKSCache(path, log)
+		err = cache.initCache(context.Background())
+		require.NoError(t, err)
+
+		set := cache.KeySet()
+		require.Equal(t, 1, set.Len())
+
+		key, ok := set.LookupKeyID("mykey")
+		require.True(t, ok)
+		require.NotNil(t, key)
+
+		// Sleep 1s before writing the file
+		time.Sleep(time.Second)
+
+		// Update the file and verify it's picked up
+		err = os.WriteFile(path, []byte(testJWKS2), 0o666)
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			return cache.KeySet().Len() == 2
+		}, 5*time.Second, 50*time.Millisecond)
+
+		set = cache.KeySet()
+		key, ok = set.LookupKeyID("mykey")
+		require.True(t, ok)
+		require.NotNil(t, key)
+		key, ok = set.LookupKeyID("testkey")
+		require.True(t, ok)
+		require.NotNil(t, key)
+	})
+
+	t.Run("init with HTTP client", func(t *testing.T) {
+		// Create a custom HTTP client with a RoundTripper that doesn't require starting a TCP listener
+		client := &http.Client{
+			Transport: roundTripFn(func(r *http.Request) *http.Response {
+				if r.Method != http.MethodGet || r.URL.Path != "/jwks.json" {
+					return &http.Response{
+						StatusCode: http.StatusNotFound,
+						Header:     make(http.Header),
+					}
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"content-type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(testJWKS1)),
+				}
+			}),
+		}
+
+		cache := NewJWKSCache("http://localhost/jwks.json", log)
+		cache.SetHTTPClient(client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		err := cache.initCache(ctx)
+		require.NoError(t, err)
+
+		set := cache.KeySet()
+		require.Equal(t, 1, set.Len())
+
+		key, ok := set.LookupKeyID("mykey")
+		require.True(t, ok)
+		require.NotNil(t, key)
+	})
+}
+
+type roundTripFn func(req *http.Request) *http.Response
+
+func (f roundTripFn) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}


### PR DESCRIPTION
Adds the "jwkscache" package, which contains a struct that can be used to create a cache of a JWKS (JWK Set). 

It supports retrieving a JWKS from:

- A path on the local disk. This is watched with fsnotify to automatically reload the JWKS when the file changes on disk.
- A HTTP(S) URL. This is automatically refreshed if a caller requests a key that isn't in the cached set.
- A JWKS passed during initialization, optionally base64-encoded.

This is currently in use by the [JWKS crypto component](https://github.com/dapr/components-contrib/blob/0221ad7edff3f33cb28fa6c7e6d8dcaee44bd5fb/crypto/jwks/component.go) (code has been extrapolated from there, and it now includes some bug fixes and the addition of tests). We are going to need it in the runtime too for Sentry (see work going on in dapr/dapr#6171)