### PR TITLE
ParseKey: ignore trailing newlines when parsing base64-encoded keys

### DIFF
--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -76,8 +76,8 @@ func ParseKey(raw []byte, contentType string) (jwk.Key, error) {
 }
 
 func parseSymmetricKey(raw []byte) (jwk.Key, error) {
-	// Try parsing as base64; first: remove any padding if present
-	trimmedRaw := bytes.TrimRight(raw, "=")
+	// Try parsing as base64; first: remove any padding (and trailing newlines) if present
+	trimmedRaw := bytes.TrimRight(raw, "\n=")
 
 	// Try parsing as base64-standard
 	dst := make([]byte, base64.RawStdEncoding.DecodedLen(len(raw)))

--- a/crypto/keys_test.go
+++ b/crypto/keys_test.go
@@ -71,8 +71,12 @@ func TestSymmetricKeys(t *testing.T) {
 	t.Run("raw bytes", testSymmetricKey(rawKey, ""))
 	t.Run("base64 standard with padding", testSymmetricKey([]byte(base64.StdEncoding.EncodeToString(rawKey)), ""))
 	t.Run("base64 standard without padding", testSymmetricKey([]byte(base64.RawStdEncoding.EncodeToString(rawKey)), ""))
+	t.Run("base64 standard with padding and trailing newline", testSymmetricKey([]byte(base64.StdEncoding.EncodeToString(rawKey)+"\n"), ""))
+	t.Run("base64 standard without padding and trailing newline", testSymmetricKey([]byte(base64.RawStdEncoding.EncodeToString(rawKey)+"\n"), ""))
 	t.Run("base64 url with padding", testSymmetricKey([]byte(base64.URLEncoding.EncodeToString(rawKey)), ""))
 	t.Run("base64 url without padding", testSymmetricKey([]byte(base64.RawURLEncoding.EncodeToString(rawKey)), ""))
+	t.Run("base64 url with padding and trailing newline", testSymmetricKey([]byte(base64.URLEncoding.EncodeToString(rawKey)+"\n"), ""))
+	t.Run("base64 url without padding and trailing newline", testSymmetricKey([]byte(base64.RawURLEncoding.EncodeToString(rawKey)+"\n"), ""))
 	t.Run("JSON with content-type", testSymmetricKey(rawKeyJSON, "application/json"))
 	t.Run("JSON without content-type", testSymmetricKey(rawKeyJSON, ""))
 }


### PR DESCRIPTION
This is something I found while working on the quickstarts.

Tools like `openssl rand -base64` automatically append a newline at the end of the base64-encoded keys they generate. These failed to be parsed with dapr/kit, throwing an error.

This PR changes the parser to remove trailing newlines when parsing a base64-encoded key.