### PR TITLE
Use correct package name in queue/processor_unit.go

### DIFF
--- a/events/queue/eventqueue.go
+++ b/events/queue/eventqueue.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package eventqueue implements a queue processor for delayed events.
+// Package queue implements a queue processor for delayed events.
 // Events are maintained in an in-memory queue, where items are in the order of when they are to be executed.
 // Users should interact with the Processor to process events in the queue.
 // When the queue has at least 1 item, the processor uses a single background goroutine to wait on the next item to be executed.

--- a/events/queue/processor_unit.go
+++ b/events/queue/processor_unit.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package eventqueue
+package queue
 
 import (
 	kclock "k8s.io/utils/clock"


### PR DESCRIPTION
This was missed from https://github.com/dapr/kit/pull/59

/cc @berndverst 