### PR TITLE
Use mocked clock in cron tests, rather than wall clock

### DIFF
--- a/cron/spec_test.go
+++ b/cron/spec_test.go
@@ -14,7 +14,6 @@ You can check the original license at:
 		https://github.com/robfig/cron/blob/master/LICENSE
 */
 
-//nolint
 package cron
 
 import (


### PR DESCRIPTION
PR updates the cron tests to use a mocked clock instead of the wall in order to speed up the tests from ~40s to ~1.5s. This also has the benefit of controlling time so that tests are more deterministic.
