### PR TITLE
Tiny: use `Load` instead of `CompareAndSwap` for detecting recoveries

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -159,7 +159,7 @@ func NotifyRecover(operation backoff.Operation, b backoff.BackOff, notify backof
 	return backoff.RetryNotify(func() error {
 		err := operation()
 
-		if err == nil && notified.CompareAndSwap(true, false) {
+		if err == nil && notified.Load() {
 			recovered()
 		}
 
@@ -178,7 +178,7 @@ func NotifyRecoverWithData[T any](operation backoff.OperationWithData[T], b back
 	return backoff.RetryNotifyWithData(func() (T, error) {
 		res, err := operation()
 
-		if err == nil && notified.CompareAndSwap(true, false) {
+		if err == nil && notified.Load() {
 			recovered()
 		}
 


### PR DESCRIPTION
Should be _slightly_ faster

There's no need to reset `notified` to `false`, since if there's no error, the operation is not retried.