### PR TITLE
feat: enable original key to be returned for metadata property fields

### DIFF
--- a/metadata/utils.go
+++ b/metadata/utils.go
@@ -23,18 +23,17 @@ import (
 )
 
 // GetMetadataProperty returns a property from the metadata map, with support for case-insensitive keys and aliases.
-func GetMetadataProperty(props map[string]string, keys ...string) (val string, ok bool) {
+func GetMetadataProperty(props map[string]string, keys ...string) (key string, val string, ok bool) {
 	lcProps := make(map[string]string, len(props))
 	for k, v := range props {
 		lcProps[strings.ToLower(k)] = v
 	}
 	for _, k := range keys {
-		val, ok = lcProps[strings.ToLower(k)]
-		if ok {
-			return val, true
+		if v, found := lcProps[strings.ToLower(k)]; found {
+			return k, v, true
 		}
 	}
-	return "", false
+	return "", "", false
 }
 
 // DecodeMetadata decodes a component metadata into a struct.


### PR DESCRIPTION
# Description

components contrib metadata updates needs us to return the original key back here

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
