### PR TITLE
Add placement error code

### DIFF
--- a/errors/codes.go
+++ b/errors/codes.go
@@ -30,6 +30,7 @@ const (
 	CodePrefixNameResolution     = "DAPR_NAME_RESOLUTION_"
 	CodePrefixMiddleware         = "DAPR_MIDDLEWARE_"
 	CodePrefixCryptography       = "DAPR_CRYPTOGRAPHY_"
+	CodePrefixPlacement          = "DAPR_PLACEMENT_"
 
 	// State
 	CodePostfixGetStateFailed      = "GET_STATE_FAILED"


### PR DESCRIPTION
# Description

Add a prefix error code to the kit to be used in the error handling of the placement api. The error code will be used in the .WithErrorInfo() function to provide detailed information for the placement error api. This PR is related to Error Standardization: Placement API #7490. 

## Issue reference

This PR will close issue : Add Placement error code #90

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x ] Code compiles correctly
* [x ] Created/updated tests
