### PR TITLE
Adds FIFO concurrent lock & generic concurrent Slice

### DIFF
--- a/concurrency/cmap/atomic.go
+++ b/concurrency/cmap/atomic.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package concurrency
+package cmap
 
 import (
 	"sync"
@@ -43,7 +43,7 @@ func (a *AtomicValue[T]) Add(v T) T {
 	return a.value
 }
 
-type AtomicMap[K comparable, T constraints.Integer] interface {
+type Atomic[K comparable, T constraints.Integer] interface {
 	Get(key K) (*AtomicValue[T], bool)
 	GetOrCreate(key K, createT T) *AtomicValue[T]
 	Delete(key K)
@@ -56,7 +56,7 @@ type atomicMap[K comparable, T constraints.Integer] struct {
 	items map[K]*AtomicValue[T]
 }
 
-func NewAtomicMap[K comparable, T constraints.Integer]() AtomicMap[K, T] {
+func NewAtomic[K comparable, T constraints.Integer]() Atomic[K, T] {
 	return &atomicMap[K, T]{
 		items: make(map[K]*AtomicValue[T]),
 	}

--- a/concurrency/cmap/atomic_test.go
+++ b/concurrency/cmap/atomic_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package concurrency
+package cmap
 
 import (
 	"sync"
@@ -21,8 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAtomicMapInt32_New_Get_Delete(t *testing.T) {
-	m := NewAtomicMap[string, int32]().(*atomicMap[string, int32])
+func TestAtomicInt32_New_Get_Delete(t *testing.T) {
+	m := NewAtomic[string, int32]().(*atomicMap[string, int32])
 
 	require.NotNil(t, m)
 	require.NotNil(t, m.items)

--- a/concurrency/cmap/map.go
+++ b/concurrency/cmap/map.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package concurrency
+package cmap
 
 import (
 	"sync"

--- a/concurrency/cmap/mutex.go
+++ b/concurrency/cmap/mutex.go
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package concurrency
+package cmap
 
 import (
 	"sync"
 )
 
-// MutexMap is an interface that defines a thread-safe map with keys of type T associated to
+// Mutex is an interface that defines a thread-safe map with keys of type T associated to
 // read-write mutexes (sync.RWMutex), allowing for granular locking on a per-key basis.
 // This can be useful for scenarios where fine-grained concurrency control is needed.
 //
@@ -31,7 +31,7 @@ import (
 // - ItemCount() int: Returns the number of items (mutexes) in the map.
 // - DeleteUnlock(key T): Removes the mutex associated with the given key from the map and releases the lock.
 // - DeleteRUnlock(key T): Removes the mutex associated with the given key from the map and releases the read lock.
-type MutexMap[T comparable] interface {
+type Mutex[T comparable] interface {
 	Lock(key T)
 	Unlock(key T)
 	RLock(key T)
@@ -43,18 +43,18 @@ type MutexMap[T comparable] interface {
 	DeleteRUnlock(key T)
 }
 
-type mutexMap[T comparable] struct {
+type mutex[T comparable] struct {
 	lock  sync.RWMutex
 	items map[T]*sync.RWMutex
 }
 
-func NewMutexMap[T comparable]() MutexMap[T] {
-	return &mutexMap[T]{
+func NewMutex[T comparable]() Mutex[T] {
+	return &mutex[T]{
 		items: make(map[T]*sync.RWMutex),
 	}
 }
 
-func (a *mutexMap[T]) Lock(key T) {
+func (a *mutex[T]) Lock(key T) {
 	a.lock.RLock()
 	mutex, ok := a.items[key]
 	a.lock.RUnlock()
@@ -73,7 +73,7 @@ func (a *mutexMap[T]) Lock(key T) {
 	mutex.Lock()
 }
 
-func (a *mutexMap[T]) Unlock(key T) {
+func (a *mutex[T]) Unlock(key T) {
 	a.lock.RLock()
 	mutex, ok := a.items[key]
 	if ok {
@@ -82,7 +82,7 @@ func (a *mutexMap[T]) Unlock(key T) {
 	a.lock.RUnlock()
 }
 
-func (a *mutexMap[T]) RLock(key T) {
+func (a *mutex[T]) RLock(key T) {
 	a.lock.RLock()
 	mutex, ok := a.items[key]
 	a.lock.RUnlock()
@@ -102,7 +102,7 @@ func (a *mutexMap[T]) RLock(key T) {
 	mutex.RLock()
 }
 
-func (a *mutexMap[T]) RUnlock(key T) {
+func (a *mutex[T]) RUnlock(key T) {
 	a.lock.RLock()
 	mutex, ok := a.items[key]
 	if ok {
@@ -111,13 +111,13 @@ func (a *mutexMap[T]) RUnlock(key T) {
 	a.lock.RUnlock()
 }
 
-func (a *mutexMap[T]) Delete(key T) {
+func (a *mutex[T]) Delete(key T) {
 	a.lock.Lock()
 	delete(a.items, key)
 	a.lock.Unlock()
 }
 
-func (a *mutexMap[T]) DeleteUnlock(key T) {
+func (a *mutex[T]) DeleteUnlock(key T) {
 	a.lock.Lock()
 	mutex, ok := a.items[key]
 	if ok {
@@ -127,7 +127,7 @@ func (a *mutexMap[T]) DeleteUnlock(key T) {
 	a.lock.Unlock()
 }
 
-func (a *mutexMap[T]) DeleteRUnlock(key T) {
+func (a *mutex[T]) DeleteRUnlock(key T) {
 	a.lock.Lock()
 	mutex, ok := a.items[key]
 	if ok {
@@ -137,13 +137,13 @@ func (a *mutexMap[T]) DeleteRUnlock(key T) {
 	a.lock.Unlock()
 }
 
-func (a *mutexMap[T]) Clear() {
+func (a *mutex[T]) Clear() {
 	a.lock.Lock()
 	clear(a.items)
 	a.lock.Unlock()
 }
 
-func (a *mutexMap[T]) ItemCount() int {
+func (a *mutex[T]) ItemCount() int {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	return len(a.items)

--- a/concurrency/cmap/mutex_test.go
+++ b/concurrency/cmap/mutex_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package concurrency
+package cmap
 
 import (
 	"sync"
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewMutexMap_Add_Delete(t *testing.T) {
-	mm := NewMutexMap[string]().(*mutexMap[string])
+func TestNewMutex_Add_Delete(t *testing.T) {
+	mm := NewMutex[string]().(*mutex[string])
 
 	t.Run("New mutex map", func(t *testing.T) {
 		require.NotNil(t, mm)

--- a/concurrency/fifo/map.go
+++ b/concurrency/fifo/map.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fifo
+
+// Map is a map of mutexes whose locks are acquired in a FIFO order. The map is
+// pruned automatically when all locks have been released for a key.
+type Map[T comparable] interface {
+	Lock(key T)
+	Unlock(key T)
+}
+
+type mapItem struct {
+	ilen  uint64
+	mutex *Mutex
+}
+
+type fifoMap[T comparable] struct {
+	lock  *Mutex
+	items map[T]*mapItem
+}
+
+func NewMap[T comparable]() Map[T] {
+	return &fifoMap[T]{
+		lock:  New(),
+		items: make(map[T]*mapItem),
+	}
+}
+
+func (a *fifoMap[T]) Lock(key T) {
+	a.lock.Lock()
+	m, ok := a.items[key]
+	if !ok {
+		m = &mapItem{mutex: New()}
+		a.items[key] = m
+	}
+	m.ilen++
+	a.lock.Unlock()
+
+	m.mutex.Lock()
+}
+
+func (a *fifoMap[T]) Unlock(key T) {
+	a.lock.Lock()
+	m := a.items[key]
+	m.ilen--
+	if m.ilen == 0 {
+		delete(a.items, key)
+	}
+	a.lock.Unlock()
+	m.mutex.Unlock()
+}

--- a/concurrency/fifo/map_test.go
+++ b/concurrency/fifo/map_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fifo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Map(t *testing.T) {
+	m := NewMap[string]().(*fifoMap[string])
+
+	assert.Empty(t, m.items)
+
+	m.Lock("key1")
+	assert.Len(t, m.items, 1)
+	assert.Equal(t, uint64(1), m.items["key1"].ilen)
+
+	go func() {
+		m.Lock("key1")
+	}()
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		m.lock.Lock()
+		assert.Equal(c, uint64(2), m.items["key1"].ilen)
+		m.lock.Unlock()
+	}, time.Second*3, time.Millisecond*10)
+
+	m.Unlock("key1")
+	assert.Equal(t, uint64(1), m.items["key1"].ilen)
+
+	m.Unlock("key1")
+	assert.Empty(t, m.items)
+}

--- a/concurrency/fifo/mutex.go
+++ b/concurrency/fifo/mutex.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fifo
+
+// Mutex is a mutex lock whose lock and unlock operations are
+// first-in-first-out (FIFO).
+type Mutex struct {
+	lock chan struct{}
+}
+
+func New() *Mutex {
+	return &Mutex{
+		lock: make(chan struct{}, 1),
+	}
+}
+
+func (m *Mutex) Lock() {
+	m.lock <- struct{}{}
+}
+
+func (m *Mutex) Unlock() {
+	<-m.lock
+}

--- a/concurrency/slice.go
+++ b/concurrency/slice.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concurrency
+
+import "sync"
+
+// Slice is a concurrent safe types slice
+type Slice[T any] interface {
+	Add(...T) int
+	Len() int
+	Slice() []T
+}
+
+type slice[T any] struct {
+	lock sync.RWMutex
+	data []T
+}
+
+func NewSlice[T any]() Slice[T] {
+	return new(slice[T])
+}
+
+func (s *slice[T]) Add(items ...T) int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.data = append(s.data, items...)
+	return len(s.data)
+}
+
+func (s *slice[T]) Len() int {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return len(s.data)
+}
+
+func (s *slice[T]) Slice() []T {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.data
+}


### PR DESCRIPTION
Adds a new concurrency/fifo package which implements a fifo mutex, as well as a concurrently safe comparable indexed map of fifo mutexes.

Adds a simple generic concurrently safe slice implementation, which can currently only grow.

Moves the map generic implementations in `/concurrency` to `/concurrency/cmap`.