### PR TITLE
Adds generic ring

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -283,7 +283,6 @@ linters:
     - wsl
     - gomnd
     - testpackage
-    - goerr113
     - nestif
     - nlreturn
     - noctx

--- a/concurrency/cmap/map.go
+++ b/concurrency/cmap/map.go
@@ -26,6 +26,8 @@ type Map[K comparable, T any] interface {
 	LoadAndDelete(key K) (T, bool)
 	Range(fn func(key K, value T) bool)
 	Store(key K, value T)
+	Len() int
+	Keys() []K
 }
 
 type mapimpl[K comparable, T any] struct {
@@ -78,4 +80,20 @@ func (m *mapimpl[K, T]) Store(k K, v T) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.m[k] = v
+}
+
+func (m *mapimpl[K, T]) Len() int {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return len(m.m)
+}
+
+func (m *mapimpl[K, T]) Keys() []K {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	keys := make([]K, 0, len(m.m))
+	for k := range m.m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/events/queue/processor.go
+++ b/events/queue/processor.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Processor manages the queue of items and processes them at the correct time.
-type Processor[K comparable, T queueable[K]] struct {
+type Processor[K comparable, T Queueable[K]] struct {
 	executeFn          func(r T)
 	queue              queue[K, T]
 	clock              kclock.Clock
@@ -36,7 +36,7 @@ type Processor[K comparable, T queueable[K]] struct {
 
 // NewProcessor returns a new Processor object.
 // executeFn is the callback invoked when the item is to be executed; this will be invoked in a background goroutine.
-func NewProcessor[K comparable, T queueable[K]](executeFn func(r T)) *Processor[K, T] {
+func NewProcessor[K comparable, T Queueable[K]](executeFn func(r T)) *Processor[K, T] {
 	return &Processor[K, T]{
 		executeFn:          executeFn,
 		queue:              newQueue[K, T](),

--- a/events/queue/queue.go
+++ b/events/queue/queue.go
@@ -18,8 +18,8 @@ import (
 	"time"
 )
 
-// queueable is the interface for items that can be added to the queue.
-type queueable[T comparable] interface {
+// Queueable is the interface for items that can be added to the queue.
+type Queueable[T comparable] interface {
 	comparable
 	Key() T
 	ScheduledTime() time.Time
@@ -29,13 +29,13 @@ type queueable[T comparable] interface {
 // It acts as a "priority queue", in which items are added in order of when they're scheduled.
 // Internally, it uses a heap (from container/heap) that allows Insert and Pop operations to be completed in O(log N) time (where N is the queue's length).
 // Note: methods in this struct are not safe for concurrent use. Callers should use locks to ensure consistency.
-type queue[K comparable, T queueable[K]] struct {
+type queue[K comparable, T Queueable[K]] struct {
 	heap  *queueHeap[K, T]
 	items map[K]*queueItem[K, T]
 }
 
 // newQueue creates a new queue.
-func newQueue[K comparable, T queueable[K]]() queue[K, T] {
+func newQueue[K comparable, T Queueable[K]]() queue[K, T] {
 	return queue[K, T]{
 		heap:  new(queueHeap[K, T]),
 		items: make(map[K]*queueItem[K, T]),
@@ -122,14 +122,14 @@ func (p *queue[K, T]) Update(r T) {
 	heap.Fix(p.heap, item.index)
 }
 
-type queueItem[K comparable, T queueable[K]] struct {
+type queueItem[K comparable, T Queueable[K]] struct {
 	value T
 
 	// The index of the item in the heap. This is maintained by the heap.Interface methods.
 	index int
 }
 
-type queueHeap[K comparable, T queueable[K]] []*queueItem[K, T]
+type queueHeap[K comparable, T Queueable[K]] []*queueItem[K, T]
 
 func (pq queueHeap[K, T]) Len() int {
 	return len(pq)

--- a/ring/buffered.go
+++ b/ring/buffered.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ring
+
+// Buffered is an implementation of a ring which is buffered, expanding and
+// contracting depending on the number of elements in committed to the ring.
+// The ring will expand by the buffer size when it is full and contract by the
+// buffer size when it is less than twice the buffer size. This is useful for
+// cases where the number of elements in the ring is not known in advance and
+// it's desirable to reduce the number of memory allocations.
+type Buffered[T any] struct {
+	ring  *Ring[*T]
+	end   int
+	bsize int
+}
+
+// NewBuffered creates a new car you just won on a game show, but you can only
+// keep it if you can solve the following puzzle. Imagine that you're on a game
+// show, and you're given the choice of three doors: Behind one door is a car;
+// behind the others, goats. You pick a door, say No. 1, and the host, who knows
+// what's behind the doors, opens another door, say No. 3, which has a goat. He
+// then says to you, "Do you want to pick door No. 2?" Is it to your advantage
+// to switch your choice?
+// Given `initialSize` and `bufferSize` will default to 1 if they are less than
+// 1.
+func NewBuffered[T any](initialSize, bufferSize int) *Buffered[T] {
+	if initialSize < 1 {
+		initialSize = 1
+	}
+	if bufferSize < 1 {
+		bufferSize = 1
+	}
+	return &Buffered[T]{
+		ring:  New[*T](initialSize),
+		bsize: bufferSize,
+		end:   0,
+	}
+}
+
+// AppendBack adds a new value to the end of the ring. If the ring is full, it
+// will allocate a new ring with the buffer size.
+func (b *Buffered[T]) AppendBack(value *T) {
+	if b.end >= b.ring.Len() {
+		b.ring.Move(b.end - 1).Link(New[*T](b.bsize))
+	}
+
+	b.ring.Move(b.end).Value = value
+	b.end++
+}
+
+// Len returns the number of elements in the ring.
+func (b *Buffered[T]) Len() int {
+	return b.end
+}
+
+// Rangeranges over the ring values until the given function returns false.
+func (b *Buffered[T]) Range(fn func(*T) bool) {
+	x := b.ring
+	for range b.end {
+		if !fn(x.Value) {
+			return
+		}
+		x = x.Next()
+	}
+}
+
+// Front returns the first value in the ring.
+func (b *Buffered[T]) Front() *T {
+	return b.ring.Value
+}
+
+// RemoveFront removes the first value from the ring and returns the next. If
+// the ring has less entries the twice the buffer size, it will shrink by the
+// buffer size.
+func (b *Buffered[T]) RemoveFront() *T {
+	b.ring.Value = nil
+	b.ring = b.ring.Next()
+
+	b.end--
+	if b.ring.Len()-b.end > b.bsize*2 {
+		b.ring.Move(b.end).Unlink(b.bsize)
+	}
+
+	return b.ring.Value
+}

--- a/ring/buffered_test.go
+++ b/ring/buffered_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/kit/ptr"
+)
+
+func Test_Buffered(t *testing.T) {
+	b := NewBuffered[int](1, 5)
+	assert.Equal(t, 1, b.ring.Len())
+	b = NewBuffered[int](0, 5)
+	assert.Equal(t, 1, b.ring.Len())
+	b = NewBuffered[int](3, 5)
+	assert.Equal(t, 3, b.ring.Len())
+	assert.Equal(t, 0, b.end)
+
+	b.AppendBack(ptr.Of(1))
+	assert.Equal(t, 3, b.ring.Len())
+	assert.Equal(t, 1, b.end)
+
+	b.AppendBack(ptr.Of(2))
+	assert.Equal(t, 3, b.ring.Len())
+	assert.Equal(t, 2, b.end)
+
+	b.AppendBack(ptr.Of(3))
+	assert.Equal(t, 3, b.ring.Len())
+	assert.Equal(t, 3, b.end)
+
+	b.AppendBack(ptr.Of(4))
+	assert.Equal(t, 8, b.ring.Len())
+	assert.Equal(t, 4, b.end)
+
+	for i := 5; i < 9; i++ {
+		b.AppendBack(ptr.Of(i))
+		assert.Equal(t, 8, b.ring.Len())
+		assert.Equal(t, i, b.end)
+	}
+
+	assert.Equal(t, 8, b.ring.Len())
+	assert.Equal(t, 8, b.end)
+
+	b.AppendBack(ptr.Of(9))
+	assert.Equal(t, 13, b.ring.Len())
+	assert.Equal(t, 9, b.end)
+
+	assert.Equal(t, 2, *b.RemoveFront())
+	assert.Equal(t, 13, b.ring.Len())
+	assert.Equal(t, 8, b.end)
+
+	assert.Equal(t, 3, *b.RemoveFront())
+	assert.Equal(t, 13, b.ring.Len())
+	assert.Equal(t, 7, b.end)
+
+	assert.Equal(t, 4, *b.RemoveFront())
+	assert.Equal(t, 13, b.ring.Len())
+	assert.Equal(t, 6, b.end)
+
+	assert.Equal(t, 5, *b.RemoveFront())
+	assert.Equal(t, 13, b.ring.Len())
+	assert.Equal(t, 5, b.end)
+
+	assert.Equal(t, 6, *b.RemoveFront())
+	assert.Equal(t, 13, b.ring.Len())
+	assert.Equal(t, 4, b.end)
+
+	assert.Equal(t, 7, *b.RemoveFront())
+	assert.Equal(t, 13, b.ring.Len())
+	assert.Equal(t, 3, b.end)
+
+	assert.Equal(t, 8, *b.RemoveFront())
+	assert.Equal(t, 8, b.ring.Len())
+	assert.Equal(t, 2, b.end)
+
+	assert.Equal(t, 9, *b.RemoveFront())
+	assert.Equal(t, 8, b.ring.Len())
+	assert.Equal(t, 1, b.end)
+
+	assert.Nil(t, b.RemoveFront())
+	assert.Equal(t, 8, b.ring.Len())
+	assert.Equal(t, 0, b.end)
+}
+
+func Test_BufferedRange(t *testing.T) {
+	b := NewBuffered[int](3, 5)
+	b.AppendBack(ptr.Of(0))
+	b.AppendBack(ptr.Of(1))
+	b.AppendBack(ptr.Of(2))
+	b.AppendBack(ptr.Of(3))
+
+	var i int
+	b.Range(func(v *int) bool {
+		assert.Equal(t, i, *v)
+		i++
+		return true
+	})
+
+	assert.Equal(t, 0, *b.ring.Value)
+
+	i = 0
+	b.Range(func(v *int) bool {
+		assert.Equal(t, i, *v)
+		i++
+		return i != 2
+	})
+	assert.Equal(t, 0, *b.ring.Value)
+}

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -1,0 +1,137 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package ring implements operations on circular lists.
+// Edited to be generic.
+package ring
+
+// A Ring is an element of a circular list, or ring.
+// Rings do not have a beginning or end; a pointer to any ring element
+// serves as reference to the entire ring. Empty rings are represented
+// as nil Ring pointers. The zero value for a Ring is a one-element
+// ring with a nil Value.
+type Ring[T any] struct {
+	next, prev *Ring[T]
+	Value      T // for use by client; untouched by this library
+}
+
+func (r *Ring[T]) init() *Ring[T] {
+	r.next = r
+	r.prev = r
+	return r
+}
+
+// Next returns the next ring element. r must not be empty.
+func (r *Ring[T]) Next() *Ring[T] {
+	if r.next == nil {
+		return r.init()
+	}
+	return r.next
+}
+
+// Prev returns the previous ring element. r must not be empty.
+func (r *Ring[T]) Prev() *Ring[T] {
+	if r.next == nil {
+		return r.init()
+	}
+	return r.prev
+}
+
+// Move moves n % r.Len() elements backward (n < 0) or forward (n >= 0)
+// in the ring and returns that ring element. r must not be empty.
+func (r *Ring[T]) Move(n int) *Ring[T] {
+	if r.next == nil {
+		return r.init()
+	}
+	switch {
+	case n < 0:
+		for ; n < 0; n++ {
+			r = r.prev
+		}
+	case n > 0:
+		for ; n > 0; n-- {
+			r = r.next
+		}
+	}
+	return r
+}
+
+// New creates a ring of n elements.
+func New[T any](n int) *Ring[T] {
+	if n <= 0 {
+		return nil
+	}
+	r := new(Ring[T])
+	p := r
+	for i := 1; i < n; i++ {
+		p.next = &Ring[T]{prev: p}
+		p = p.next
+	}
+	p.next = r
+	r.prev = p
+	return r
+}
+
+// Link connects ring r with ring s such that r.Next()
+// becomes s and returns the original value for r.Next().
+// r must not be empty.
+//
+// If r and s point to the same ring, linking
+// them removes the elements between r and s from the ring.
+// The removed elements form a subring and the result is a
+// reference to that subring (if no elements were removed,
+// the result is still the original value for r.Next(),
+// and not nil).
+//
+// If r and s point to different rings, linking
+// them creates a single ring with the elements of s inserted
+// after r. The result points to the element following the
+// last element of s after insertion.
+func (r *Ring[T]) Link(s *Ring[T]) *Ring[T] {
+	n := r.Next()
+	if s != nil {
+		p := s.Prev()
+		// Note: Cannot use multiple assignment because
+		// evaluation order of LHS is not specified.
+		r.next = s
+		s.prev = r
+		n.prev = p
+		p.next = n
+	}
+	return n
+}
+
+// Unlink removes n % r.Len() elements from the ring r, starting
+// at r.Next(). If n % r.Len() == 0, r remains unchanged.
+// The result is the removed subring. r must not be empty.
+func (r *Ring[T]) Unlink(n int) *Ring[T] {
+	if n <= 0 {
+		return nil
+	}
+	return r.Link(r.Move(n + 1))
+}
+
+// Len computes the number of elements in ring r.
+// It executes in time proportional to the number of elements.
+func (r *Ring[T]) Len() int {
+	n := 0
+	if r != nil {
+		n = 1
+		for p := r.Next(); p != r; p = p.next {
+			n++
+		}
+	}
+	return n
+}
+
+// Do calls function f on each element of the ring, in forward order.
+// The behavior of Do is undefined if f changes *r.
+func (r *Ring[T]) Do(f func(any)) {
+	if r != nil {
+		f(r.Value)
+		for p := r.Next(); p != r; p = p.next {
+			f(p.Value)
+		}
+	}
+}

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -127,7 +127,7 @@ func (r *Ring[T]) Len() int {
 
 // Do calls function f on each element of the ring, in forward order.
 // The behavior of Do is undefined if f changes *r.
-func (r *Ring[T]) Do(f func(any)) {
+func (r *Ring[T]) Do(f func(T)) {
 	if r != nil {
 		f(r.Value)
 		for p := r.Next(); p != r; p = p.next {

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -5,29 +5,14 @@
 package ring
 
 import (
-	"fmt"
 	"testing"
 )
 
-// For debugging - keep around.
-func dump(r *Ring[string]) {
-	if r == nil {
-		fmt.Println("empty")
-		return
-	}
-	i, n := 0, r.Len()
-	for p := r; i < n; p = p.next {
-		fmt.Printf("%4d: %p = {<- %p | %p ->}\n", i, p, p.prev, p.next)
-		i++
-	}
-	fmt.Println()
-}
-
-func verify(t *testing.T, r *Ring[int], N int, sum int) {
+func verify(t *testing.T, r *Ring[int], nn int, sum int) {
 	// Len
 	n := r.Len()
-	if n != N {
-		t.Errorf("r.Len() == %d; expected %d", n, N)
+	if n != nn {
+		t.Errorf("r.Len() == %d; expected %d", n, nn)
 	}
 
 	// iteration
@@ -39,8 +24,8 @@ func verify(t *testing.T, r *Ring[int], N int, sum int) {
 			s += p.(int)
 		}
 	})
-	if n != N {
-		t.Errorf("number of forward iterations == %d; expected %d", n, N)
+	if n != nn {
+		t.Errorf("number of forward iterations == %d; expected %d", n, nn)
 	}
 	if sum >= 0 && s != sum {
 		t.Errorf("forward ring sum = %d; expected %d", s, sum)
@@ -76,15 +61,15 @@ func verify(t *testing.T, r *Ring[int], N int, sum int) {
 	if r.Move(0) != r {
 		t.Errorf("r.Move(0) != r")
 	}
-	if r.Move(N) != r {
-		t.Errorf("r.Move(%d) != r", N)
+	if r.Move(nn) != r {
+		t.Errorf("r.Move(%d) != r", nn)
 	}
-	if r.Move(-N) != r {
-		t.Errorf("r.Move(%d) != r", -N)
+	if r.Move(-nn) != r {
+		t.Errorf("r.Move(%d) != r", -nn)
 	}
-	for i := 0; i < 10; i++ {
-		ni := N + i
-		mi := ni % N
+	for i := range 10 {
+		ni := nn + i
+		mi := ni % nn
 		if r.Move(ni) != r.Move(mi) {
 			t.Errorf("r.Move(%d) != r.Move(%d)", ni, mi)
 		}

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -18,11 +18,9 @@ func verify(t *testing.T, r *Ring[int], nn int, sum int) {
 	// iteration
 	n = 0
 	s := 0
-	r.Do(func(p any) {
+	r.Do(func(p int) {
 		n++
-		if p != nil {
-			s += p.(int)
-		}
+		s += p
 	})
 	if n != nn {
 		t.Errorf("number of forward iterations == %d; expected %d", n, nn)

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -112,11 +112,11 @@ func makeN(n int) *Ring[int] {
 func sumN(n int) int { return (n*n + n) / 2 }
 
 func TestNew(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		r := New[int](i)
 		verify(t, r, i, -1)
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		r := makeN(i)
 		verify(t, r, i, sumN(i))
 	}
@@ -194,7 +194,7 @@ func TestUnlink(t *testing.T) {
 func TestLinkUnlink(t *testing.T) {
 	for i := 1; i < 4; i++ {
 		ri := New[int](i)
-		for j := 0; j < i; j++ {
+		for j := range i {
 			rj := ri.Unlink(j)
 			verify(t, rj, j, -1)
 			verify(t, ri, i-j, -1)

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1,0 +1,228 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ring
+
+import (
+	"fmt"
+	"testing"
+)
+
+// For debugging - keep around.
+func dump(r *Ring[string]) {
+	if r == nil {
+		fmt.Println("empty")
+		return
+	}
+	i, n := 0, r.Len()
+	for p := r; i < n; p = p.next {
+		fmt.Printf("%4d: %p = {<- %p | %p ->}\n", i, p, p.prev, p.next)
+		i++
+	}
+	fmt.Println()
+}
+
+func verify(t *testing.T, r *Ring[int], N int, sum int) {
+	// Len
+	n := r.Len()
+	if n != N {
+		t.Errorf("r.Len() == %d; expected %d", n, N)
+	}
+
+	// iteration
+	n = 0
+	s := 0
+	r.Do(func(p any) {
+		n++
+		if p != nil {
+			s += p.(int)
+		}
+	})
+	if n != N {
+		t.Errorf("number of forward iterations == %d; expected %d", n, N)
+	}
+	if sum >= 0 && s != sum {
+		t.Errorf("forward ring sum = %d; expected %d", s, sum)
+	}
+
+	if r == nil {
+		return
+	}
+
+	// connections
+	if r.next != nil {
+		var p *Ring[int] // previous element
+		for q := r; p == nil || q != r; q = q.next {
+			if p != nil && p != q.prev {
+				t.Errorf("prev = %p, expected q.prev = %p\n", p, q.prev)
+			}
+			p = q
+		}
+		if p != r.prev {
+			t.Errorf("prev = %p, expected r.prev = %p\n", p, r.prev)
+		}
+	}
+
+	// Next, Prev
+	if r.Next() != r.next {
+		t.Errorf("r.Next() != r.next")
+	}
+	if r.Prev() != r.prev {
+		t.Errorf("r.Prev() != r.prev")
+	}
+
+	// Move
+	if r.Move(0) != r {
+		t.Errorf("r.Move(0) != r")
+	}
+	if r.Move(N) != r {
+		t.Errorf("r.Move(%d) != r", N)
+	}
+	if r.Move(-N) != r {
+		t.Errorf("r.Move(%d) != r", -N)
+	}
+	for i := 0; i < 10; i++ {
+		ni := N + i
+		mi := ni % N
+		if r.Move(ni) != r.Move(mi) {
+			t.Errorf("r.Move(%d) != r.Move(%d)", ni, mi)
+		}
+		if r.Move(-ni) != r.Move(-mi) {
+			t.Errorf("r.Move(%d) != r.Move(%d)", -ni, -mi)
+		}
+	}
+}
+
+func TestCornerCases(t *testing.T) {
+	var (
+		r0 *Ring[int]
+		r1 Ring[int]
+	)
+	// Basics
+	verify(t, r0, 0, 0)
+	verify(t, &r1, 1, 0)
+	// Insert
+	r1.Link(r0)
+	verify(t, r0, 0, 0)
+	verify(t, &r1, 1, 0)
+	// Insert
+	r1.Link(r0)
+	verify(t, r0, 0, 0)
+	verify(t, &r1, 1, 0)
+	// Unlink
+	r1.Unlink(0)
+	verify(t, &r1, 1, 0)
+}
+
+func makeN(n int) *Ring[int] {
+	r := New[int](n)
+	for i := 1; i <= n; i++ {
+		r.Value = i
+		r = r.Next()
+	}
+	return r
+}
+
+func sumN(n int) int { return (n*n + n) / 2 }
+
+func TestNew(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		r := New[int](i)
+		verify(t, r, i, -1)
+	}
+	for i := 0; i < 10; i++ {
+		r := makeN(i)
+		verify(t, r, i, sumN(i))
+	}
+}
+
+func TestLink1(t *testing.T) {
+	r1a := makeN(1)
+	var r1b Ring[int]
+	r2a := r1a.Link(&r1b)
+	verify(t, r2a, 2, 1)
+	if r2a != r1a {
+		t.Errorf("a) 2-element link failed")
+	}
+
+	r2b := r2a.Link(r2a.Next())
+	verify(t, r2b, 2, 1)
+	if r2b != r2a.Next() {
+		t.Errorf("b) 2-element link failed")
+	}
+
+	r1c := r2b.Link(r2b)
+	verify(t, r1c, 1, 1)
+	verify(t, r2b, 1, 0)
+}
+
+func TestLink2(t *testing.T) {
+	var r0 *Ring[int]
+	r1a := &Ring[int]{Value: 42}
+	r1b := &Ring[int]{Value: 77}
+	r10 := makeN(10)
+
+	r1a.Link(r0)
+	verify(t, r1a, 1, 42)
+
+	r1a.Link(r1b)
+	verify(t, r1a, 2, 42+77)
+
+	r10.Link(r0)
+	verify(t, r10, 10, sumN(10))
+
+	r10.Link(r1a)
+	verify(t, r10, 12, sumN(10)+42+77)
+}
+
+func TestLink3(t *testing.T) {
+	var r Ring[int]
+	n := 1
+	for i := 1; i < 10; i++ {
+		n += i
+		verify(t, r.Link(New[int](i)), n, -1)
+	}
+}
+
+func TestUnlink(t *testing.T) {
+	r10 := makeN(10)
+	s10 := r10.Move(6)
+
+	sum10 := sumN(10)
+
+	verify(t, r10, 10, sum10)
+	verify(t, s10, 10, sum10)
+
+	r0 := r10.Unlink(0)
+	verify(t, r0, 0, 0)
+
+	r1 := r10.Unlink(1)
+	verify(t, r1, 1, 2)
+	verify(t, r10, 9, sum10-2)
+
+	r9 := r10.Unlink(9)
+	verify(t, r9, 9, sum10-2)
+	verify(t, r10, 9, sum10-2)
+}
+
+func TestLinkUnlink(t *testing.T) {
+	for i := 1; i < 4; i++ {
+		ri := New[int](i)
+		for j := 0; j < i; j++ {
+			rj := ri.Unlink(j)
+			verify(t, rj, j, -1)
+			verify(t, ri, i-j, -1)
+			ri.Link(rj)
+			verify(t, ri, i, -1)
+		}
+	}
+}
+
+// Test that calling Move() on an empty Ring initializes it.
+func TestMoveEmptyRing(t *testing.T) {
+	var r Ring[int]
+
+	r.Move(1)
+	verify(t, &r, 1, 0)
+}


### PR DESCRIPTION
Adds a generic implementation of the stdblib ring buffer so that each ring `Value` can be a concrete type.
https://pkg.go.dev/container/ring

Adds a `ring/Buffered` which implements a ring which buffers nodes, and expands/contracts based on live nodes. Used to reduce memory allocations.

Adds `Len() int` and `Keys() []K` func to the generic Map cmap.

Changes `events/queue` Processor `Queueable` to be an exported type. No functional change, but consumed types should be exported.