### PR TITLE
Add error code and category funcs

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -56,6 +56,9 @@ type Error struct {
 
 	// Tag is a string identifying the error, used with HTTP responses only.
 	tag string
+
+	// Category is a string identifying the category of the error, used for error code metrics only.
+	category string
 }
 
 // ErrorBuilder is used to build the error
@@ -82,6 +85,22 @@ func (e *Error) HTTPStatusCode() int {
 // GrpcStatusCode gets the error grpc code
 func (e *Error) GrpcStatusCode() grpcCodes.Code {
 	return e.grpcCode
+}
+
+// ErrorCode returns the error code from the error
+func (e *Error) ErrorCode() string {
+	for _, detail := range e.details {
+		if _, ok := detail.(*errdetails.ErrorInfo); ok {
+			_, errorCode := convertErrorDetails(detail, *e)
+			return errorCode
+		}
+	}
+	return ""
+}
+
+// Category returns the error code's category
+func (e *Error) Category() string {
+	return e.category
 }
 
 // Error implements the error interface.
@@ -334,7 +353,7 @@ ErrorBuilder
 **************************************/
 
 // NewBuilder create a new ErrorBuilder using the supplied required error fields
-func NewBuilder(grpcCode grpcCodes.Code, httpCode int, message string, tag string) *ErrorBuilder {
+func NewBuilder(grpcCode grpcCodes.Code, httpCode int, message string, tag string, category string) *ErrorBuilder {
 	return &ErrorBuilder{
 		err: Error{
 			details:  make([]proto.Message, 0),
@@ -342,6 +361,7 @@ func NewBuilder(grpcCode grpcCodes.Code, httpCode int, message string, tag strin
 			httpCode: httpCode,
 			message:  message,
 			tag:      tag,
+			category: category,
 		},
 	}
 }


### PR DESCRIPTION
# Description

In order to support error code metrics, sometimes the category will need to be passed along with a kit error, as well as the ability to retrieve it and its error code.

## Issue reference
Please reference the issue this PR will close: https://github.com/dapr/proposals/pull/67

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
