### PR TITLE
concurrency/lock: Adds context and outercancel locks

### DIFF
--- a/concurrency/lock/context.go
+++ b/concurrency/lock/context.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lock
+
+import (
+	"context"
+	"sync"
+)
+
+// Context is a ready write mutex lock where Locking can return early with an
+// error if the context is done. No error response means the lock is acquired.
+type Context struct {
+	lock   sync.RWMutex
+	locked chan struct{}
+}
+
+func NewContext() *Context {
+	return &Context{
+		locked: make(chan struct{}, 1),
+	}
+}
+
+func (c *Context) Lock(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case c.locked <- struct{}{}:
+		c.lock.Lock()
+		return nil
+	}
+}
+
+func (c *Context) Unlock() {
+	c.lock.Unlock()
+	<-c.locked
+}
+
+func (c *Context) RLock(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case c.locked <- struct{}{}:
+		c.lock.RLock()
+		return nil
+	}
+}
+
+func (c *Context) RUnlock() {
+	c.lock.RUnlock()
+	<-c.locked
+}

--- a/concurrency/lock/context_test.go
+++ b/concurrency/lock/context_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Context(t *testing.T) {
+	tests := map[string]struct {
+		name        string
+		action      func(l *Context) error
+		expectError bool
+	}{
+		"Successful Lock": {
+			action: func(l *Context) error {
+				return l.Lock(context.Background())
+			},
+			expectError: false,
+		},
+		"Lock with Context Timeout": {
+			action: func(l *Context) error {
+				l.Lock(context.Background())
+				ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+				defer cancel()
+				return l.Lock(ctx)
+			},
+			expectError: true,
+		},
+		"Successful RLock": {
+			action: func(l *Context) error {
+				return l.RLock(context.Background())
+			},
+			expectError: false,
+		},
+		"RLock with Context Timeout": {
+			action: func(l *Context) error {
+				l.Lock(context.Background())
+				ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+				defer cancel()
+				return l.RLock(ctx)
+			},
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			l := NewContext()
+
+			done := make(chan error)
+			go func() {
+				done <- test.action(l)
+			}()
+
+			select {
+			case err := <-done:
+				assert.Equal(t, (err != nil), test.expectError, "unexpected error, expected error: %v, got: %v", test.expectError, err)
+			case <-time.After(time.Second):
+				t.Errorf("test timed out")
+			}
+		})
+	}
+}

--- a/concurrency/lock/outercancel.go
+++ b/concurrency/lock/outercancel.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lock
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/dapr/kit/concurrency/fifo"
+)
+
+var errLockClosed = errors.New("lock closed")
+
+type hold struct {
+	writeLock bool
+	rctx      context.Context
+	respCh    chan *holdresp
+}
+
+type holdresp struct {
+	rctx   context.Context
+	cancel context.CancelFunc
+	err    error
+}
+
+type OuterCancel struct {
+	ch chan *hold
+
+	lock chan struct{}
+
+	wg          sync.WaitGroup
+	rcancelLock sync.Mutex
+	rcancelx    uint64
+	rcancels    map[uint64]context.CancelFunc
+
+	closeCh      chan struct{}
+	shutdownLock *fifo.Mutex
+}
+
+func NewOuterCancel() *OuterCancel {
+	return &OuterCancel{
+		lock:         make(chan struct{}, 1),
+		ch:           make(chan *hold, 1),
+		rcancels:     make(map[uint64]context.CancelFunc),
+		closeCh:      make(chan struct{}),
+		shutdownLock: fifo.New(),
+	}
+}
+
+func (o *OuterCancel) Run(ctx context.Context) {
+	defer func() {
+		o.rcancelLock.Lock()
+		defer o.rcancelLock.Unlock()
+
+		for _, cancel := range o.rcancels {
+			go cancel()
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		close(o.closeCh)
+	}()
+
+	for {
+		select {
+		case <-o.closeCh:
+			return
+		case h := <-o.ch:
+			o.handleHold(h)
+		}
+	}
+}
+
+func (o *OuterCancel) handleHold(h *hold) {
+	if h.rctx != nil {
+		select {
+		case o.lock <- struct{}{}:
+		case <-h.rctx.Done():
+			h.respCh <- &holdresp{err: h.rctx.Err()}
+			return
+		}
+	} else {
+		o.lock <- struct{}{}
+	}
+
+	o.rcancelLock.Lock()
+
+	if h.writeLock {
+		for _, cancel := range o.rcancels {
+			go cancel()
+		}
+		o.rcancelx = 0
+		o.rcancelLock.Unlock()
+		o.wg.Wait()
+
+		h.respCh <- &holdresp{cancel: func() { <-o.lock }}
+
+		return
+	}
+
+	o.wg.Add(1)
+	var done bool
+	doneCh := make(chan bool)
+	rctx, cancel := context.WithCancelCause(h.rctx)
+	i := o.rcancelx
+
+	rcancel := func() {
+		o.rcancelLock.Lock()
+		if !done {
+			close(doneCh)
+			cancel(errors.New("placement is disseminating"))
+			delete(o.rcancels, i)
+			o.wg.Done()
+			done = true
+		}
+		o.rcancelLock.Unlock()
+	}
+
+	rcancelGrace := func() {
+		select {
+		case <-time.After(2 * time.Second):
+		case <-o.closeCh:
+		case <-doneCh:
+		}
+		rcancel()
+	}
+
+	o.rcancels[i] = rcancelGrace
+	o.rcancelx++
+
+	o.rcancelLock.Unlock()
+
+	h.respCh <- &holdresp{rctx: rctx, cancel: rcancel}
+
+	<-o.lock
+}
+
+func (o *OuterCancel) Lock() context.CancelFunc {
+	h := hold{
+		writeLock: true,
+		respCh:    make(chan *holdresp, 1),
+	}
+
+	select {
+	case <-o.closeCh:
+		o.shutdownLock.Lock()
+		return o.shutdownLock.Unlock
+	case o.ch <- &h:
+	}
+
+	select {
+	case <-o.closeCh:
+		o.shutdownLock.Lock()
+		return o.shutdownLock.Unlock
+	case resp := <-h.respCh:
+		return resp.cancel
+	}
+}
+
+func (o *OuterCancel) RLock(ctx context.Context) (context.Context, context.CancelFunc, error) {
+	h := hold{
+		writeLock: false,
+		rctx:      ctx,
+		respCh:    make(chan *holdresp, 1),
+	}
+
+	select {
+	case <-o.closeCh:
+		return nil, nil, errLockClosed
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case o.ch <- &h:
+	}
+
+	select {
+	case <-o.closeCh:
+		return nil, nil, errLockClosed
+	case resp := <-h.respCh:
+		return resp.rctx, resp.cancel, resp.err
+	}
+}

--- a/concurrency/lock/outercancel_test.go
+++ b/concurrency/lock/outercancel_test.go
@@ -29,7 +29,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("can rlock multiple times", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""))
+		l := NewOuterCancel(errors.New(""), time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -66,7 +66,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("rlock unlock removes cancel state", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""))
+		l := NewOuterCancel(errors.New(""), time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -92,7 +92,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("calling lock cancels all current rlocks", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""))
+		l := NewOuterCancel(errors.New(""), time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -122,7 +122,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("rlock when closed should error", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""))
+		l := NewOuterCancel(errors.New(""), time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -142,7 +142,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("lock continues to work after close", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""))
+		l := NewOuterCancel(errors.New(""), time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -158,7 +158,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("rlock blocks until outter unlocks", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""))
+		l := NewOuterCancel(errors.New(""), time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -192,7 +192,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("lock blocks until outter unlocks", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""))
+		l := NewOuterCancel(errors.New(""), time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)

--- a/concurrency/lock/outercancel_test.go
+++ b/concurrency/lock/outercancel_test.go
@@ -26,10 +26,12 @@ import (
 func Test_OuterCancel(t *testing.T) {
 	t.Parallel()
 
+	terr := errors.New("test")
+
 	t.Run("can rlock multiple times", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""), time.Second)
+		l := NewOuterCancel(terr, time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -66,7 +68,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("rlock unlock removes cancel state", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""), time.Second)
+		l := NewOuterCancel(terr, time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -92,7 +94,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("calling lock cancels all current rlocks", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""), time.Second)
+		l := NewOuterCancel(terr, time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -122,7 +124,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("rlock when closed should error", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""), time.Second)
+		l := NewOuterCancel(terr, time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -142,7 +144,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("lock continues to work after close", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""), time.Second)
+		l := NewOuterCancel(terr, time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -158,7 +160,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("rlock blocks until outter unlocks", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""), time.Second)
+		l := NewOuterCancel(terr, time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -192,7 +194,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("lock blocks until outter unlocks", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel(errors.New(""), time.Second)
+		l := NewOuterCancel(terr, time.Second)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)

--- a/concurrency/lock/outercancel_test.go
+++ b/concurrency/lock/outercancel_test.go
@@ -15,6 +15,7 @@ package lock
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -28,7 +29,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("can rlock multiple times", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel()
+		l := NewOuterCancel(errors.New(""))
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -65,7 +66,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("rlock unlock removes cancel state", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel()
+		l := NewOuterCancel(errors.New(""))
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -91,7 +92,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("calling lock cancels all current rlocks", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel()
+		l := NewOuterCancel(errors.New(""))
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -121,7 +122,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("rlock when closed should error", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel()
+		l := NewOuterCancel(errors.New(""))
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -141,7 +142,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("lock continues to work after close", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel()
+		l := NewOuterCancel(errors.New(""))
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -157,7 +158,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("rlock blocks until outter unlocks", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel()
+		l := NewOuterCancel(errors.New(""))
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -191,7 +192,7 @@ func Test_OuterCancel(t *testing.T) {
 	t.Run("lock blocks until outter unlocks", func(t *testing.T) {
 		t.Parallel()
 
-		l := NewOuterCancel()
+		l := NewOuterCancel(errors.New(""))
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)

--- a/concurrency/lock/outercancel_test.go
+++ b/concurrency/lock/outercancel_test.go
@@ -26,6 +26,7 @@ import (
 func Test_OuterCancel(t *testing.T) {
 	t.Parallel()
 
+	//nolint:err113
 	terr := errors.New("test")
 
 	t.Run("can rlock multiple times", func(t *testing.T) {

--- a/concurrency/lock/outercancel_test.go
+++ b/concurrency/lock/outercancel_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_OuterCancel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("can rlock multiple times", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewOuterCancel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		ctx1, c1, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx2, c2, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx3, c3, err := l.RLock(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, ctx1.Err())
+		require.NoError(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		c1()
+		require.Error(t, ctx1.Err())
+		require.NoError(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		c2()
+		require.Error(t, ctx1.Err())
+		require.Error(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		c3()
+		require.Error(t, ctx1.Err())
+		require.Error(t, ctx2.Err())
+		require.Error(t, ctx3.Err())
+	})
+
+	t.Run("rlock unlock removes cancel state", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewOuterCancel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		_, c1, err := l.RLock(ctx)
+		require.NoError(t, err)
+		_, c2, err := l.RLock(ctx)
+		require.NoError(t, err)
+		_, c3, err := l.RLock(ctx)
+		require.NoError(t, err)
+
+		assert.Len(t, l.rcancels, 3)
+		c1()
+		assert.Len(t, l.rcancels, 2)
+		c2()
+		assert.Len(t, l.rcancels, 1)
+		c3()
+		assert.Empty(t, l.rcancels, 0)
+	})
+
+	t.Run("calling lock cancels all current rlocks", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewOuterCancel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		ctx1, _, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx2, _, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx3, _, err := l.RLock(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, ctx1.Err())
+		require.NoError(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		mcancel := l.Lock()
+		require.Error(t, ctx1.Err())
+		require.Error(t, ctx2.Err())
+		require.Error(t, ctx3.Err())
+		mcancel()
+
+		assert.Empty(t, l.rcancels)
+	})
+
+	t.Run("rlock when closed should error", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewOuterCancel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		go l.Run(ctx)
+
+		select {
+		case <-l.closeCh:
+		case <-time.After(time.Second * 5):
+			assert.Fail(t, "expected close")
+		}
+
+		_, _, err := l.RLock(context.Background())
+		require.Error(t, err)
+	})
+
+	t.Run("lock continues to work after close", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewOuterCancel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		l.Run(ctx)
+
+		lcancel := l.Lock()
+		lcancel()
+		lcancel = l.Lock()
+		lcancel()
+	})
+
+	t.Run("rlock blocks until outter unlocks", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewOuterCancel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		lcancel := l.Lock()
+
+		gotRLock := make(chan struct{})
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, c1, err := l.RLock(ctx)
+			errCh <- err
+			t.Cleanup(c1)
+			close(gotRLock)
+		}()
+		t.Cleanup(func() {
+			require.NoError(t, <-errCh)
+		})
+
+		select {
+		case <-time.After(time.Millisecond * 500):
+		case <-gotRLock:
+			require.Fail(t, "unexpected rlock")
+		}
+
+		lcancel()
+	})
+
+	t.Run("lock blocks until outter unlocks", func(t *testing.T) {
+		t.Parallel()
+
+		l := NewOuterCancel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		lcancel := l.Lock()
+
+		gotLock := make(chan struct{})
+
+		go func() {
+			lockcancel := l.Lock()
+			t.Cleanup(lockcancel)
+			close(gotLock)
+		}()
+
+		select {
+		case <-time.After(time.Millisecond * 500):
+		case <-gotLock:
+			require.Fail(t, "unexpected rlock")
+		}
+
+		lcancel()
+	})
+}


### PR DESCRIPTION
Adds context lock which will cancel and return an error to Lock & RLock if the given context cancels before the lock is achieved.

Adds outercancel lock which will cancel all RLocks in progress if the outer Lock is called.