### PR TITLE
pem: do not exclude self-signed certificates when encoding X509 chain

### DIFF
--- a/crypto/pem/pem.go
+++ b/crypto/pem/pem.go
@@ -142,8 +142,6 @@ func EncodeX509(cert *x509.Certificate) ([]byte, error) {
 }
 
 // EncodeX509Chain will encode a list of *x509.Certificates into a PEM format chain.
-// Self-signed certificates are not included as per
-// https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.2
 // Certificates are output in the order they're given; if the input is not ordered
 // as specified in RFC5246 section 7.4.2, the resulting chain might not be valid
 // for use in TLS.
@@ -155,11 +153,6 @@ func EncodeX509Chain(certs []*x509.Certificate) ([]byte, error) {
 	certPEM := bytes.NewBuffer([]byte{})
 	for _, cert := range certs {
 		if cert == nil {
-			continue
-		}
-
-		if cert.CheckSignatureFrom(cert) == nil {
-			// Don't include self-signed certificate
 			continue
 		}
 

--- a/crypto/pem/pem_test.go
+++ b/crypto/pem/pem_test.go
@@ -1,0 +1,18 @@
+package pem
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecodePEMChain(t *testing.T) {
+	chain, err := DecodePEMCertificatesChain([]byte(selfSignedRootCert))
+	require.NoError(t, err)
+	require.NotEmpty(t, chain)
+
+	chainPEM, err := EncodeX509Chain(chain)
+	require.NoError(t, err)
+	require.NotEmpty(t, chainPEM)
+	require.Equal(t, string(selfSignedRootCert), string(chainPEM))
+}

--- a/crypto/pem/testdata_test.go
+++ b/crypto/pem/testdata_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pem
+
+const (
+	// good for 30 years
+	selfSignedRootCert = `-----BEGIN CERTIFICATE-----
+MIIBYjCCAQegAwIBAgIRAKTEJxGnjLLxJHupLBXWs4EwCgYIKoZIzj0EAwIwDzEN
+MAsGA1UEAxMEcm9vdDAgFw0yNTA4MjcxMDAzNDFaGA8yMDU1MDgyMDEwMDM0MVow
+DzENMAsGA1UEAxMEcm9vdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFK+gysd
+ykg3PGGeMxupM+I/14VAQzHyUiBY5gCb/TwLPbsGVmr+IQhcVv9qrEUntBkURtsR
+QIvpxgo1vdcDdrKjQjBAMA4GA1UdDwEB/wQEAwICpDAPBgNVHRMBAf8EBTADAQH/
+MB0GA1UdDgQWBBR8yVxFTE2lUXehLqNPNPPb7aAxmzAKBggqhkjOPQQDAgNJADBG
+AiEAnLIvHFK/8tg1+A5GmqBAga4CsgnBsBlaYE0nWGxhULACIQDNG7+1ibiKui7y
+asNeuhl1GHo6ODBdh/8jPYtdwu9+DA==
+-----END CERTIFICATE-----
+` // #nosec G101
+)


### PR DESCRIPTION
# Description

[RFC 5246](https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.2) states that:

```
      Because certificate validation requires that root keys be distributed
      independently, the self-signed certificate that specifies the root
      certificate authority MAY be omitted from the chain, under the
      assumption that the remote end must already possess it in order to
      validate it in any case.
```

Since it's not saying they MUST be omitted we can keep the self-signed certs and keep symmetry in the encode/decode functions.