### PR TITLE
fix: windows pipe - construct SDDL with user ID

### DIFF
--- a/signals/pipe_windows.go
+++ b/signals/pipe_windows.go
@@ -34,7 +34,7 @@ func ReloadPipeName(pid int) string {
 // The pipe is secured so that the current user, Built-in Administrators,
 // and Local System have full access.
 //
-// This now uses the user's actual SId ratehr than a CO SID.
+// This now uses the user's actual SID rather than a Creator Owner (CO) SID.
 func listenPipe(name string) (net.Listener, error) {
 	sd, err := buildPipeSecurityDescriptor()
 	if err != nil {

--- a/signals/pipe_windows.go
+++ b/signals/pipe_windows.go
@@ -16,6 +16,7 @@ package signals
 import (
 	"fmt"
 	"net"
+	"os/user"
 	"strconv"
 	"time"
 
@@ -30,13 +31,30 @@ func ReloadPipeName(pid int) string {
 }
 
 // listenPipe creates a Windows named pipe listener at the given path.
-// The pipe is secured so that the creating user (Creator Owner),
-// Built-in Administrators, and Local System have full access.
+// The pipe is secured so that the current user, Built-in Administrators,
+// and Local System have full access.
+//
+// This now uses the user's actual SId ratehr than a CO SID.
 func listenPipe(name string) (net.Listener, error) {
+	sd, err := buildPipeSecurityDescriptor()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build pipe security descriptor: %w", err)
+	}
 	return winio.ListenPipe(name, &winio.PipeConfig{
-		// CO = Creator Owner, BA = Built-in Administrators, SY = Local System.
-		SecurityDescriptor: "D:P(A;;GA;;;CO)(A;;GA;;;BA)(A;;GA;;;SY)",
+		SecurityDescriptor: sd,
 	})
+}
+
+// buildPipeSecurityDescriptor constructs an SDDL string granting full access to
+// the current user, Built-in Administrators, and Local System.
+// Note: inheritance is disabled.
+func buildPipeSecurityDescriptor() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("failed to look up current user: %w", err)
+	}
+	// Current User / Administrators / Local System
+	return fmt.Sprintf("D:P(A;;GA;;;%s)(A;;GA;;;BA)(A;;GA;;;SY)", u.Uid), nil
 }
 
 // SignalReload connects to the reload named pipe for the given PID, triggering

--- a/signals/pipe_windows.go
+++ b/signals/pipe_windows.go
@@ -14,10 +14,12 @@ limitations under the License.
 package signals
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os/user"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Microsoft/go-winio"
@@ -53,8 +55,30 @@ func buildPipeSecurityDescriptor() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to look up current user: %w", err)
 	}
+	if err := validateWindowsSID(u.Uid); err != nil {
+		return "", fmt.Errorf("invalid current user SID %q: %w", u.Uid, err)
+	}
 	// Current User / Administrators / Local System
 	return fmt.Sprintf("D:P(A;;GA;;;%s)(A;;GA;;;BA)(A;;GA;;;SY)", u.Uid), nil
+}
+
+// validateWindowsSID returns a non-nil error if s is not a syntactically valid
+func validateWindowsSID(s string) error {
+	if s == "" {
+		return errors.New("empty SID")
+	}
+	if !strings.HasPrefix(s, "S-1-") {
+		return errors.New("not a Windows SID")
+	}
+	for _, part := range strings.Split(s[2:], "-") {
+		if part == "" {
+			return errors.New("malformed SID")
+		}
+		if _, err := strconv.ParseUint(part, 10, 64); err != nil {
+			return fmt.Errorf("malformed SID component %q", part)
+		}
+	}
+	return nil
 }
 
 // SignalReload connects to the reload named pipe for the given PID, triggering

--- a/signals/pipe_windows_test.go
+++ b/signals/pipe_windows_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signals
+
+import (
+	"os/user"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPipeSecurityDescriptor(t *testing.T) {
+	sd, err := buildPipeSecurityDescriptor()
+	require.NoError(t, err)
+
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	// Must be a protected DACL (D:P) granting GA to current user, built-in admins and system.
+	assert.True(t, strings.HasPrefix(sd, "D:P"), "SDDL should start with protected DACL marker D:P, got %q", sd)
+	assert.Contains(t, sd, "(A;;GA;;;"+u.Uid+")", "SDDL should grant GA to current user SID")
+	assert.Contains(t, sd, "(A;;GA;;;BA)", "SDDL should grant GA to Built-in Administrators")
+	assert.Contains(t, sd, "(A;;GA;;;SY)", "SDDL should grant GA to Local System")
+}

--- a/signals/pipe_windows_test.go
+++ b/signals/pipe_windows_test.go
@@ -22,6 +22,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateWindowsSID(t *testing.T) {
+	tests := []struct {
+		name    string
+		sid     string
+		wantErr bool
+	}{
+		{"valid local system", "S-1-5-18", false},
+		{"valid user sid", "S-1-2-34-5678901234-5678901234-5678901234-5678901234", false},
+		{"valid creator owner", "S-1-3-0", false},
+		{"empty", "", true},
+		{"missing prefix", "1-5-18", true},
+		{"wrong revision", "S-2-5-18", true},
+		{"trailing dash", "S-1-5-18-", true},
+		{"double dash", "S-1-5--18", true},
+		{"non-numeric component", "S-1-5-abc", true},
+		{"negative component", "S-1-5--1", true},
+		{"overflow component", "S-1-5-18446744073709551616", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateWindowsSID(tc.sid)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestBuildPipeSecurityDescriptor(t *testing.T) {
 	sd, err := buildPipeSecurityDescriptor()
 	require.NoError(t, err)


### PR DESCRIPTION
# Description

Resolves access denied pipe issues downstream with hotreloading now enabled.

Tested working with the runtime in standalone mode

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
