### PR TITLE
crypto/spiffe: add ECDSA key algorithm

### DIFF
--- a/crypto/spiffe/spiffe.go
+++ b/crypto/spiffe/spiffe.go
@@ -16,7 +16,9 @@ package spiffe
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -58,6 +60,11 @@ const (
 	// certificates are consumed by systems that do not accept Ed25519, such
 	// as the Kubernetes API server when calling admission webhooks.
 	KeyAlgorithmRSA
+
+	// KeyAlgorithmECDSA generates an ECDSA P-256 private key. Used by workloads
+	// whose certificates are consumed by systems that accept neither Ed25519
+	// nor RSA-only paths and require ECDSA, such as AWS IAM Roles Anywhere.
+	KeyAlgorithmECDSA
 )
 
 // SVIDResponse represents the response from the SVID request function,
@@ -373,6 +380,8 @@ func generatePrivateKey(alg KeyAlgorithm) (crypto.Signer, error) {
 	switch alg {
 	case KeyAlgorithmRSA:
 		return rsa.GenerateKey(rand.Reader, rsaKeyBits)
+	case KeyAlgorithmECDSA:
+		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	case KeyAlgorithmEd25519:
 		_, key, err := ed25519.GenerateKey(rand.Reader)
 		if err != nil {

--- a/crypto/spiffe/spiffe_test.go
+++ b/crypto/spiffe/spiffe_test.go
@@ -15,7 +15,9 @@ package spiffe
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/x509"
 	"errors"
@@ -138,6 +140,7 @@ func Test_fetchIdentity_keyAlgorithm(t *testing.T) {
 
 	rsaAlg := KeyAlgorithmRSA
 	edAlg := KeyAlgorithmEd25519
+	ecdsaAlg := KeyAlgorithmECDSA
 
 	tests := map[string]struct {
 		alg    *KeyAlgorithm
@@ -161,6 +164,14 @@ func Test_fetchIdentity_keyAlgorithm(t *testing.T) {
 				rsaKey, ok := key.(*rsa.PrivateKey)
 				require.True(t, ok, "expected *rsa.PrivateKey, got %T", key)
 				assert.Equal(t, rsaKeyBits, rsaKey.N.BitLen())
+			},
+		},
+		"ECDSA generates an ECDSA P-256 private key": {
+			alg: &ecdsaAlg,
+			assert: func(t *testing.T, key any) {
+				ecKey, ok := key.(*ecdsa.PrivateKey)
+				require.True(t, ok, "expected *ecdsa.PrivateKey, got %T", key)
+				assert.Equal(t, elliptic.P256(), ecKey.Curve)
 			},
 		},
 	}


### PR DESCRIPTION
# Description

Adds ECDSA to the list available key algorithms, main driver is AWS Roles Anywhere that does not support ED25519