### PR TITLE
handle @every schedule with timezone

### DIFF
--- a/cron/doc.go
+++ b/cron/doc.go
@@ -182,6 +182,10 @@ For example:
 
 The prefix "TZ=(TIME ZONE)" is also supported for legacy compatibility.
 
+A time zone prefix is not supported on "@every <duration>" schedules. These fire
+at a fixed interval rather than at a wall-clock time, so there is no wall clock
+for a time zone to apply to, and such a schedule is rejected at parse time.
+
 Be aware that jobs scheduled during daylight-savings leap-ahead transitions will
 not be run!
 

--- a/cron/parser.go
+++ b/cron/parser.go
@@ -129,6 +129,13 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 		}
 
 		spec = strings.TrimSpace(spec[i:])
+
+		// An @every schedule fires at a fixed interval and has no wall clock for
+		// a timezone to apply to, so reject the pair rather than silently
+		// dropping the location.
+		if strings.HasPrefix(spec, "@every ") {
+			return nil, fmt.Errorf("timezone is not supported for @every schedules: %s", spec)
+		}
 	}
 
 	// Handle named schedules (descriptors), if configured

--- a/cron/parser.go
+++ b/cron/parser.go
@@ -116,6 +116,8 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
 		var err error
 
+		prefixed := spec
+
 		i := strings.IndexFunc(spec, unicode.IsSpace)
 		eq := strings.Index(spec, "=")
 
@@ -134,7 +136,7 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 		// a timezone to apply to, so reject the pair rather than silently
 		// dropping the location.
 		if strings.HasPrefix(spec, "@every ") {
-			return nil, fmt.Errorf("timezone is not supported for @every schedules: %s", spec)
+			return nil, fmt.Errorf("timezone is not supported for @every schedules: %s", prefixed)
 		}
 	}
 

--- a/cron/parser_test.go
+++ b/cron/parser_test.go
@@ -146,6 +146,8 @@ func TestParseScheduleErrors(t *testing.T) {
 		{"TZ=UTC", "not followed by a schedule"},
 		{"CRON_TZ=Asia/Tokyo", "not followed by a schedule"},
 		{"TZ=", "not followed by a schedule"},
+		{"CRON_TZ=Europe/Rome @every 1h", "not supported for @every"},
+		{"TZ=Asia/Tokyo @every 30m", "not supported for @every"},
 	}
 	for _, c := range tests {
 		actual, err := secondParser.Parse(c.expr)
@@ -161,6 +163,7 @@ func TestParseScheduleErrors(t *testing.T) {
 
 func TestParseSchedule(t *testing.T) {
 	tokyo, _ := time.LoadLocation("Asia/Tokyo")
+	rome, _ := time.LoadLocation("Europe/Rome")
 	entries := []struct {
 		parser   Parser
 		expr     string
@@ -178,6 +181,7 @@ func TestParseSchedule(t *testing.T) {
 		{secondParser, "@midnight", midnight(time.Local)}, //nolint:gosmopolitan
 		{secondParser, "TZ=UTC  @midnight", midnight(time.UTC)},
 		{secondParser, "TZ=Asia/Tokyo @midnight", midnight(tokyo)},
+		{secondParser, "CRON_TZ=Europe/Rome @daily", midnight(rome)},
 		{secondParser, "@yearly", annual(time.Local)},   //nolint:gosmopolitan
 		{secondParser, "@annually", annual(time.Local)}, //nolint:gosmopolitan
 		{
@@ -445,22 +449,15 @@ func TestParseScheduleTimezoneDST(t *testing.T) {
 	}
 }
 
-// A constant delay has no wall clock for a timezone to apply to, so the prefix
-// is accepted but has no effect.
-func TestParseScheduleTimezoneIgnoredForEvery(t *testing.T) {
-	from := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
-
-	withTZ, err := secondParser.Parse("CRON_TZ=Europe/Rome @every 1h")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// A constant delay has no wall clock for a timezone to apply to, so the pair is
+// rejected rather than silently dropping the location.
+func TestParseScheduleTimezoneRejectedForEvery(t *testing.T) {
+	if _, err := secondParser.Parse("CRON_TZ=Europe/Rome @every 1h"); err == nil {
+		t.Error("expected an error, got nil")
 	}
 
-	without, err := secondParser.Parse("@every 1h")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if !withTZ.Next(from).Equal(without.Next(from)) {
-		t.Errorf("expected %v, got %v", without.Next(from), withTZ.Next(from))
+	// An unprefixed @every is still valid.
+	if _, err := secondParser.Parse("@every 1h"); err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/cron/parser_test.go
+++ b/cron/parser_test.go
@@ -452,12 +452,16 @@ func TestParseScheduleTimezoneDST(t *testing.T) {
 // A constant delay has no wall clock for a timezone to apply to, so the pair is
 // rejected rather than silently dropping the location.
 func TestParseScheduleTimezoneRejectedForEvery(t *testing.T) {
-	if _, err := secondParser.Parse("CRON_TZ=Europe/Rome @every 1h"); err == nil {
+	_, err := secondParser.Parse("CRON_TZ=Europe/Rome @every 1h")
+	if err == nil {
 		t.Error("expected an error, got nil")
+	} else if !strings.Contains(err.Error(), "CRON_TZ=Europe/Rome @every 1h") {
+		t.Errorf("error should include the original spec, got: %v", err)
 	}
 
 	// An unprefixed @every is still valid.
-	if _, err := secondParser.Parse("@every 1h"); err != nil {
+	_, err = secondParser.Parse("@every 1h")
+	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
Fix jobs schedule parse: cannot use timezone with `@every` in schedule